### PR TITLE
fix: Port adjustment

### DIFF
--- a/service/grails-app/conf/application-vagrant-db.yml
+++ b/service/grails-app/conf/application-vagrant-db.yml
@@ -34,5 +34,5 @@ dataSource:
 ---
 server:
   host: localhost
-  port: 8077
+  port: 8076
  

--- a/service/src/main/okapi/DeploymentDescriptorDev-template.json
+++ b/service/src/main/okapi/DeploymentDescriptorDev-template.json
@@ -1,5 +1,5 @@
 {
   "srvcId": "${info.app.name}-${info.app.version}",
   "instId": "10.0.2.2-${info.app.name}-${info.app.version}",
-  "url": "http://10.0.2.2:8077/"
+  "url": "http://10.0.2.2:8076/"
 }


### PR DESCRIPTION
Adjsted ports within vagrant-db yaml and descriptor dev template from '8077' to '8076', this is most likely due to missed changes on initial setups