### PR TITLE
fix: Templating Omission/Combinations

### DIFF
--- a/service/grails-app/domain/org/olf/internalPiece/InternalPiece.groovy
+++ b/service/grails-app/domain/org/olf/internalPiece/InternalPiece.groovy
@@ -13,9 +13,16 @@ public abstract class InternalPiece implements MultiTenant<InternalPiece> {
   static mapping = {
     id column: 'ip_id', generator: 'uuid2', length: 36
     version column: 'ip_version'
-
+    templateString column: 'ip_template_string'
+    label column: 'ip_label'
 
     tablePerHierarchy false
+  }
+
+  static constraints = {
+    templateString nullable: true
+    label nullable: true
+
   }
 
   // Cannot handle ommited combination, please god no

--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationCyclicalTMRF.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationCyclicalTMRF.groovy
@@ -26,16 +26,16 @@ public class EnumerationCyclicalTMRF extends TemplateMetadataRuleFormat implemen
     EnumerationCyclicalTMRF ectmrf = rule?.ruleType?.ruleFormat
     while (true) {
       for (int i = 0; i < ectmrf?.levels?.size(); i++) {
+        index -= ectmrf?.levels[i]?.units;
         if (index <= 0) {
           return ectmrf?.levels[i]?.value;
-        }
-        index -= ectmrf?.levels[i]?.units;
-      }    
+        }    
+      }
     }
   }
 
   public static EnumerationTemplateMetadata handleFormat (TemplateMetadataRule rule, LocalDate date, int index){
-    String result = findResultIndex(rule, index)
+    String result = findResultIndex(rule, index + 1)
     return new EnumerationTemplateMetadata([value: result])
   }
 }

--- a/service/grails-app/migrations/create-mod-serials-management.groovy
+++ b/service/grails-app/migrations/create-mod-serials-management.groovy
@@ -1297,4 +1297,11 @@ databaseChangeLog = {
       column(name: "ecltmrf_internal_note", type: "TEXT") { constraints(nullable: "true") }
     }
   }
+
+  changeSet(author: "Jack-Golding (manual)", id: "20231128-1315-001") {
+    addColumn(tableName: "internal_piece") {
+      column(name: "ip_template_string", type: "TEXT") { constraints(nullable: "true") }
+      column(name: "ip_label", type: "TEXT") { constraints(nullable: "true") }
+    }
+  }
 }

--- a/service/grails-app/services/org/olf/PieceGenerationService.groovy
+++ b/service/grails-app/services/org/olf/PieceGenerationService.groovy
@@ -205,42 +205,11 @@ public class PieceGenerationService {
         }
       }
     }
+    
+    if (!!ruleset?.templateConfig) {
+      pieceLabellingService.setLabelsForInternalPieces(internalPieces, ruleset?.templateConfig)
+    }
 
-    // TODO Handling of combination pieces
-    // FIXME Correctly implement enumeration handling - currently large errors being thrown 
-    // if (!!ruleset?.templateConfig) {
-    //   ListIterator<InternalPiece> iterator = internalPieces.listIterator()
-    //   Integer index = 0
-    //   while(iterator.hasNext()){
-    //     InternalPiece currentPiece = iterator.next()
-    //     ruleset?.templateConfig?.rules.each { rule ->
-    //       if(currentPiece instanceof InternalRecurrencePiece){
-    //         String formattedRuleFormatType = RGX_REFDATA_VALUE.matcher(rule?.templateMetadataRuleType?.value).replaceAll { match -> match.group(1).toUpperCase() }
-    //         Class<? extends TemplateMetadataRuleFormat> lsc = Class.forName("org.olf.templateConfig.templateMetadataRule.${formattedRuleFormatType.capitalize()}TemplateMetadataRule")
-    //         if(formattedRuleFormatType == 'chronology'){
-    //           ChronologyTemplateMetadata metadataObject = lsc.handleStyle(rule, currentPiece.date, index)
-    //           currentPiece.addToTemplateMetadata(metadataObject)
-    //         }
-    //         else if(formattedRuleFormatType == 'enumeration'){
-    //           EnumerationTemplateMetadata enumerationLabel = new EnumerationTemplateMetadata()
-    //           ArrayList<Map> labelObject = lsc.handleStyle(rule, currentPiece.date, index)
-    //           ListIterator<Map> enumerationIterator = labelObject.listIterator()
-    //           while(enumerationIterator.hasNext()){
-    //             Map enumerationLevel = enumerationIterator.next()
-    //             enumerationLabel.addToLevels(new EnumerationTemplateMetadataLevel([
-    //               value: enumerationLevel?.value,
-    //               level: enumerationLevel?.level,
-    //             ]))
-    //           }
-    //           currentPiece.addToTemplateMetadata(enumerationLabel)
-    //         }
-    //       }
-    //     }
-    //     index ++
-    //   }   
-    // }
-
-    pieceLabellingService.setLabelsForInternalPieces(internalPieces, ruleset?.templateConfig)
     return internalPieces
   }
 }

--- a/service/grails-app/services/org/olf/PieceLabellingService.groovy
+++ b/service/grails-app/services/org/olf/PieceLabellingService.groovy
@@ -103,6 +103,7 @@ public class PieceLabellingService {
         currentIndex++
       }
     }
+    return containedIndicies
   }
 
   // Grab index of piece, treating combination pieces as individual pieces contained within
@@ -142,8 +143,8 @@ public class PieceLabellingService {
 
   public ArrayList<ChronologyTemplateMetadata> generateChronologyMetadata(StandardTemplateMetadata standardTM, ArrayList<TemplateMetadataRule> templateMetadataRules) {
     ArrayList<ChronologyTemplateMetadata> chronologyTemplateMetadataArray = []
-    ListIterator<TemplateMetadataRule> iterator = templateMetadataRules.listIterator()
-    while(iterator.hasNext()){
+    ListIterator<TemplateMetadataRule> iterator = templateMetadataRules?.listIterator()
+    while(iterator?.hasNext()){
       TemplateMetadataRule currentMetadataRule = iterator.next()
       String templateMetadataType = RGX_METADATA_RULE_TYPE.matcher(currentMetadataRule?.templateMetadataRuleType?.value).replaceAll { match -> match.group(1).toUpperCase() }
       if(templateMetadataType == 'chronology'){
@@ -157,8 +158,8 @@ public class PieceLabellingService {
 
   public ArrayList<EnumerationTemplateMetadata> generateEnumerationMetadata(StandardTemplateMetadata standardTM, ArrayList<TemplateMetadataRule> templateMetadataRules) {
     ArrayList<EnumerationTemplateMetadata> enumerationTemplateMetadataArray = []
-    ListIterator<TemplateMetadataRule> iterator = templateMetadataRules.listIterator()
-    while(iterator.hasNext()){
+    ListIterator<TemplateMetadataRule> iterator = templateMetadataRules?.listIterator()
+    while(iterator?.hasNext()){
       TemplateMetadataRule currentMetadataRule = iterator.next()
       String templateMetadataType = RGX_METADATA_RULE_TYPE.matcher(currentMetadataRule?.templateMetadataRuleType?.value).replaceAll { match -> match.group(1).toUpperCase() }
       if(templateMetadataType == 'enumeration'){

--- a/service/grails-app/services/org/olf/PieceLabellingService.groovy
+++ b/service/grails-app/services/org/olf/PieceLabellingService.groovy
@@ -96,7 +96,7 @@ public class PieceLabellingService {
       if(piece instanceof InternalRecurrencePiece && ip instanceof InternalRecurrencePiece && piece.date == ip.date){
         containedIndicies = [currentIndex]
       }else if(piece instanceof InternalCombinationPiece && (ip instanceof InternalCombinationPiece) && (ip.recurrencePieces.findIndexOf{rp -> piece.recurrencePieces.getAt(0).date == rp.date} != -1)){
-        containedIndices = new IntRange(false, currentIndex, currentIndex+ip.reccurrencePieces.size())
+        containedIndicies = new IntRange(false, currentIndex, currentIndex+ip.recurrencePieces.size())
       }else if(ip instanceof InternalCombinationPiece){
         currentIndex = currentIndex+ip.recurrencePieces.size() 
       }else{
@@ -117,7 +117,7 @@ public class PieceLabellingService {
         indexCounter ++
       }else if(p instanceof InternalCombinationPiece && piece instanceof InternalCombinationPiece && p.recurrencePieces.getAt(0).date == piece.recurrencePieces.getAt(0).date){
         return indexCounter
-      }else{
+      }else if(p instanceof InternalCombinationPiece){
         indexCounter += p.recurrencePieces.size()
       }
     }
@@ -131,7 +131,7 @@ public class PieceLabellingService {
     }else if(piece instanceof InternalCombinationPiece){
       date = piece.recurrencePieces.getAt(0).date
     }
-    
+
     Integer index = getIndex(piece, internalPieces)
     Integer naiveIndex = getNaiveIndexOfPiece(piece, internalPieces)
     ArrayList<Integer> containedIndices = getContainedIndexesFromPiece(piece, internalPieces)

--- a/service/grails-app/services/org/olf/PieceLabellingService.groovy
+++ b/service/grails-app/services/org/olf/PieceLabellingService.groovy
@@ -45,6 +45,7 @@ public class PieceLabellingService {
     LabelTemplateBindings ltb = new LabelTemplateBindings()
     ltb.setupChronologyArray(chronologyArray)
     ltb.setupEnumerationArray(enumerationArray)
+    ltb.setupStandardMetadata(standardTM)
 
     return template.make(ltb).with { 
       StringWriter sw = new StringWriter()
@@ -66,6 +67,7 @@ public class PieceLabellingService {
   }
 
   // This probably doesnt belong here, potentially in different service
+  // Grab naive index of piece, treating combination pieces a single piece, using the first date in array of recurrence pieces
   public Integer getNaiveIndexOfPiece(InternalPiece piece, ArrayList<InternalPiece> internalPieces){
     if(piece instanceof InternalRecurrencePiece){
       return internalPieces.findIndexOf{ip ->
@@ -103,6 +105,7 @@ public class PieceLabellingService {
     }
   }
 
+  // Grab index of piece, treating combination pieces as individual pieces contained within
   public Integer getIndex(InternalPiece piece, ArrayList<InternalPiece> internalPieces){
     Integer indexCounter = 0
     ListIterator<InternalPiece> iterator = internalPieces.listIterator()
@@ -121,7 +124,14 @@ public class PieceLabellingService {
   }
 
   public StandardTemplateMetadata generateStandardMetadata(InternalPiece piece, ArrayList<InternalPiece> internalPieces){
-    LocalDate date = piece.date
+    LocalDate date
+
+    if(piece instanceof InternalRecurrencePiece){
+      date = piece.date
+    }else if(piece instanceof InternalCombinationPiece){
+      date = piece.recurrencePieces.getAt(0).date
+    }
+    
     Integer index = getIndex(piece, internalPieces)
     Integer naiveIndex = getNaiveIndexOfPiece(piece, internalPieces)
     ArrayList<Integer> containedIndices = getContainedIndexesFromPiece(piece, internalPieces)

--- a/service/grails-app/services/org/olf/PieceLabellingService.groovy
+++ b/service/grails-app/services/org/olf/PieceLabellingService.groovy
@@ -45,7 +45,7 @@ public class PieceLabellingService {
     LabelTemplateBindings ltb = new LabelTemplateBindings()
     ltb.setupChronologyArray(chronologyArray)
     ltb.setupEnumerationArray(enumerationArray)
-    ltb.setupStandardMetadata(standardTM)
+    ltb.setupStandardTM(standardTM)
 
     return template.make(ltb).with { 
       StringWriter sw = new StringWriter()

--- a/service/src/main/groovy/org/olf/templating/LabelTemplateBindings.groovy
+++ b/service/src/main/groovy/org/olf/templating/LabelTemplateBindings.groovy
@@ -24,4 +24,8 @@ public class LabelTemplateBindings extends HashMap<String, Object> {
 
     this.put("enumerationArray", enumerationArray)
   }
+
+  public void setupStandardMetadata(StandardTemplateMetadata standardTM){
+    this.put("standardMetadata", standardTM)
+  }
 }

--- a/service/src/main/groovy/org/olf/templating/LabelTemplateBindings.groovy
+++ b/service/src/main/groovy/org/olf/templating/LabelTemplateBindings.groovy
@@ -25,7 +25,7 @@ public class LabelTemplateBindings extends HashMap<String, Object> {
     this.put("enumerationArray", enumerationArray)
   }
 
-  public void setupStandardMetadata(StandardTemplateMetadata standardTM){
-    this.put("standardMetadata", standardTM)
+  public void setupStandardTM(StandardTemplateMetadata standardTM){
+    this.put("standardTM", standardTM)
   }
 }


### PR DESCRIPTION
Added conditionals to standardTM date field if handling a combination piece
Fixed handling of combination/omitted pieces within piecelabellingservice
Added optional chaining to the template metadata rules if no templating rules are passed through
Fixed calculations for enumeration cyclical values
