### PR TITLE
feat: Enumeration template bindings format

### DIFF
--- a/service/src/main/groovy/org/olf/templating/LabelTemplateBindings.groovy
+++ b/service/src/main/groovy/org/olf/templating/LabelTemplateBindings.groovy
@@ -8,7 +8,7 @@ import groovy.transform.CompileStatic
 
 public class LabelTemplateBindings extends HashMap<String, Object> {
   public void setupChronologyArray(ArrayList<ChronologyTemplateMetadata> chronologyArray){
-    chronologyArray.eachWithIndex  {element, index ->
+    chronologyArray.eachWithIndex{  element, index ->
       // Bloody make sure you toString() GStrings
       this.put("chronology${index+1}".toString(), element)
     }
@@ -17,11 +17,17 @@ public class LabelTemplateBindings extends HashMap<String, Object> {
   }
 
   public void setupEnumerationArray(ArrayList<EnumerationTemplateMetadata> enumerationArray){
-    enumerationArray.eachWithIndex  {element, index ->
-      // Bloody make sure you toString() GStrings
-      this.put("enumeration${index+1}".toString(), element)
+    enumerationArray.eachWithIndex{ element, index ->
+      if(!!element?.value){
+        this.put("enumeration${index+1}".toString(), element?.value)
+      }else{
+        Map<String, Object> levelsMap = new HashMap<String, Object>()
+        element?.levels?.eachWithIndex{ level, levelIndex ->
+          levelsMap.put("level${levelIndex+1}".toString(), level?.value)
+        }
+        this.put("enumeration${index+1}".toString(), levelsMap)
+      }
     }
-
     this.put("enumerationArray", enumerationArray)
   }
 


### PR DESCRIPTION
Updated enumeration template bindings to use preffered format of {{enumeration1}} for EnumerationTextual as opposed to {{enumeration1.value}}, and  {{enumeration1.level1}} for EnumerationNumeric instead of {{enumeration.levels.0.value}}