### PR TITLE
refactor: Generate predicted pieces parameters

### DIFF
--- a/service/grails-app/controllers/org/olf/PredictedPieceSetController.groovy
+++ b/service/grails-app/controllers/org/olf/PredictedPieceSetController.groovy
@@ -42,13 +42,12 @@ class PredictedPieceSetController extends OkapiTenantAwareController<PredictedPi
 
   def generatePredictedPieces() {
     JSONObject data = request.JSON
-    Serial serial = Serial.get(data?.serial?.id)
     SerialRuleset ruleset = SerialRuleset.get(data?.ruleset?.id)
+    Serial serial = Serial.get(ruleset?.owner?.id)
     ArrayList<InternalPiece> ips = pieceGenerationService.createPiecesTransient(ruleset, LocalDate.parse(data.startDate))
 
     PredictedPieceSet pps = new PredictedPieceSet([
       serial: serial,
-      ruleset: ruleset,
       pieces: ips,
       note: data?.note,
       startDate: data?.startDate


### PR DESCRIPTION
Refactored generation and saving of predicted pieces so now only the ruleset id is required and serial is fetched from owner