### PR TITLE
fix: Template config rules nullable

### DIFF
--- a/service/grails-app/domain/org/olf/templateConfig/TemplateConfig.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/TemplateConfig.groovy
@@ -33,7 +33,7 @@ public class TemplateConfig implements MultiTenant<TemplateConfig> {
 
   static constraints = {
     owner nullable: false
-    rules nullable: false
+    rules nullable: true
     templateString nullable: false
   }
 }


### PR DESCRIPTION
Changed template configs rules contraint to be nullable, as a template string is required but rules are not