### PR TITLE
feat: Template config ordering

### DIFF
--- a/service/grails-app/domain/org/olf/PredictedPieceSet.groovy
+++ b/service/grails-app/domain/org/olf/PredictedPieceSet.groovy
@@ -30,8 +30,6 @@ class PredictedPieceSet implements MultiTenant<PredictedPieceSet> {
 
   static mappedBy = [
     pieces: 'owner',
-    // serial: 'predictedPieceSet',
-    // ruleset: 'predictedPieceSet',
   ]
 
   static mapping = {

--- a/service/grails-app/domain/org/olf/Serial.groovy
+++ b/service/grails-app/domain/org/olf/Serial.groovy
@@ -39,9 +39,6 @@ class Serial implements MultiTenant<Serial> {
     recurrence: 'owner'
   ]
 
-	// static belongsTo = [ predictedPieceSet: PredictedPieceSet ]
-
-
   static mapping = {
     id column: 's_id', generator: 'uuid2', length: 36
     lastUpdated column: 's_last_updated'

--- a/service/grails-app/domain/org/olf/templateConfig/TemplateConfig.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/TemplateConfig.groovy
@@ -28,7 +28,7 @@ public class TemplateConfig implements MultiTenant<TemplateConfig> {
     owner column: 'tc_owner_fk'
     version column: 'tc_version'
     templateString column: 'tc_template_string'
-    rules cascade: 'all-delete-orphan'
+    rules cascade: 'all-delete-orphan', sort: 'index', order: 'asc'
   }
 
   static constraints = {

--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRule/TemplateMetadataRule.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRule/TemplateMetadataRule.groovy
@@ -12,7 +12,10 @@ import com.k_int.web.toolkit.refdata.RefdataValue
 
 public class TemplateMetadataRule implements MultiTenant<TemplateMetadataRule> {
   String id
+  
   TemplateConfig owner
+
+  Integer index
 
   @CategoryId(value="TemplateMetadataRule.TemplateMetadataRuleType", defaultInternal=true)
   @Defaults(['Chronology', 'Enumeration'])
@@ -35,12 +38,14 @@ public class TemplateMetadataRule implements MultiTenant<TemplateMetadataRule> {
     id column: 'tmr_id', generator: 'uuid2', length: 36
     owner column: 'tmr_owner_fk'
     version column: 'tmr_version'
+    index column: 'tmr_index'
     templateMetadataRuleType column: 'tmr_template_metadata_rule_type_fk'
 	  ruleType cascade: 'all-delete-orphan'
   }
 
   static constraints = {
     owner nullable: false
+    index nullable: false
     templateMetadataRuleType nullable: false
     ruleType nullable: false, validator: TemplateMetadataRuleHelpers.ruleTypeValidator
   }

--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRule/TemplateMetadataRuleType.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRule/TemplateMetadataRuleType.groovy
@@ -7,8 +7,8 @@ public abstract class TemplateMetadataRuleType implements MultiTenant<TemplateMe
   TemplateMetadataRule owner
 
   static mapping = {
-         id column: 'tmrt_id', generator: 'uuid2', length: 36
-      owner column: 'tmrt_owner_fk'
+    id column: 'tmrt_id', generator: 'uuid2', length: 36
+    owner column: 'tmrt_owner_fk'
     version column: 'tmrt_version'
 
     tablePerHierarchy false

--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationNumericLevelTMRF.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationNumericLevelTMRF.groovy
@@ -9,6 +9,9 @@ import com.k_int.web.toolkit.refdata.RefdataValue
 class EnumerationNumericLevelTMRF implements MultiTenant<EnumerationNumericLevelTMRF> {
 
   String id
+
+  Integer index
+  
   Integer units
 
   @CategoryId(value="EnumerationNumericLevelTMRF.Format", defaultInternal=true)
@@ -29,6 +32,7 @@ class EnumerationNumericLevelTMRF implements MultiTenant<EnumerationNumericLevel
     id column: 'enltmrf_id', generator: 'uuid2', length: 36
     owner column: 'enltmrf_owner_fk'
     version column: 'enltmrf_version'
+    index column: 'enltmrf_index'
     units column: 'enltmrf_units'
     format column: 'enltmrf_format_fk'
     sequence column: 'enltmrf_sequence_fk'
@@ -37,6 +41,7 @@ class EnumerationNumericLevelTMRF implements MultiTenant<EnumerationNumericLevel
   
   static constraints = {
     owner(nullable:false, blank:false);
+    index nullable: false
     units nullable: false
     format nullable: false
     sequence nullable: false

--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationNumericTMRF.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationNumericTMRF.groovy
@@ -20,7 +20,7 @@ public class EnumerationNumericTMRF extends TemplateMetadataRuleFormat implement
   ]
 
   static mapping = {
-    levels cascade: 'all-delete-orphan'
+    levels cascade: 'all-delete-orphan', sort: 'index', order: 'asc'
   }
   
   static constraints = {

--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationTextualLevelTMRF.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationTextualLevelTMRF.groovy
@@ -9,6 +9,9 @@ import com.k_int.web.toolkit.refdata.RefdataValue
 class EnumerationTextualLevelTMRF implements MultiTenant<EnumerationTextualLevelTMRF> {
 
   String id
+
+  Integer index
+
   Integer units
 
   // TODO shoudld be dynamically assigned refdata
@@ -26,6 +29,7 @@ class EnumerationTextualLevelTMRF implements MultiTenant<EnumerationTextualLevel
     id column: 'etltmrf_id', generator: 'uuid2', length: 36
     owner column: 'etltmrf_owner_fk'
     version column: 'etltmrf_version'
+    index column: 'etltmrf_index'
     units column: 'etltmrf_units'
     value column: 'etltmrf_value'
     internalNote column: 'etltmrf_internal_note'
@@ -33,6 +37,7 @@ class EnumerationTextualLevelTMRF implements MultiTenant<EnumerationTextualLevel
   
   static constraints = {
     owner(nullable:false, blank:false);
+    index nullable: false
     units nullable: false
     value nullable: false
     internalNote nullable: true

--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationTextualTMRF.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationTextualTMRF.groovy
@@ -19,7 +19,7 @@ public class EnumerationTextualTMRF extends TemplateMetadataRuleFormat implement
   ]
 
   static mapping = {
-    levels cascade: 'all-delete-orphan'
+    levels cascade: 'all-delete-orphan', sort: 'index', order: 'asc'
   }
   
   static constraints = {

--- a/service/grails-app/migrations/create-mod-serials-management.groovy
+++ b/service/grails-app/migrations/create-mod-serials-management.groovy
@@ -1217,6 +1217,7 @@ databaseChangeLog = {
       column(name: "tmr_id", type: "VARCHAR(36)") { constraints(nullable: "false") }
       column(name: "tmr_owner_fk", type: "VARCHAR(36)") { constraints(nullable: "false") }
       column(name: "tmr_version", type: "BIGINT") { constraints(nullable: "false") }
+      column(name: "tmr_index", type:"INTEGER") { constraints(nullable: "false") }
       column(name: "tmr_template_metadata_rule_type_fk", type: "VARCHAR(36)") { constraints(nullable: "false") }
     }
   }
@@ -1281,6 +1282,7 @@ databaseChangeLog = {
       column(name: "enltmrf_id", type: "VARCHAR(36)") { constraints(nullable: "false") }
       column(name: "enltmrf_owner_fk", type: "VARCHAR(36)") { constraints(nullable: "false") }
       column(name: "enltmrf_version", type: "BIGINT") { constraints(nullable: "false") }
+      column(name: "enltmrf_index", type:"INTEGER") { constraints(nullable: "false") }
       column(name: "enltmrf_units", type: "BIGINT") { constraints(nullable: "false") }
       column(name: "enltmrf_format_fk", type: "VARCHAR(36)") { constraints(nullable: "false") }
       column(name: "enltmrf_sequence_fk", type: "VARCHAR(36)") { constraints(nullable: "false") }
@@ -1293,6 +1295,7 @@ databaseChangeLog = {
       column(name: "etltmrf_id", type: "VARCHAR(36)") { constraints(nullable: "false") }
       column(name: "etltmrf_owner_fk", type: "VARCHAR(36)") { constraints(nullable: "false") }
       column(name: "etltmrf_version", type: "BIGINT") { constraints(nullable: "false") }
+      column(name: "etltmrf_index", type:"INTEGER") { constraints(nullable: "false") }
       column(name: "etltmrf_units", type: "BIGINT") { constraints(nullable: "false") }
       column(name: "etltmrf_value", type: "VARCHAR(255)") { constraints(nullable: "false") }
       column(name: "etltmrf_internal_note", type: "TEXT") { constraints(nullable: "true") }


### PR DESCRIPTION
Added index properties to template metadata rules and enumeration levels to ensure order is maintained when predicted pieces are generated from database