### PR TITLE
fix: Starting value binding fix

### DIFF
--- a/service/grails-app/controllers/org/olf/PredictedPieceSetController.groovy
+++ b/service/grails-app/controllers/org/olf/PredictedPieceSetController.groovy
@@ -33,13 +33,38 @@ class PredictedPieceSetController extends OkapiTenantAwareController<PredictedPi
 
     SerialRuleset ruleset = new SerialRuleset(data)
 
+    if(ruleset?.templateConfig?.rules?.size()){
+      for(int i=0;i<ruleset?.templateConfig?.rules?.size();i++){
+        if(ruleset?.templateConfig?.rules[i]?.ruleType?.templateMetadataRuleFormat?.value == 'enumeration_numeric'){
+          for(int j=0;j<ruleset?.templateConfig?.rules[i]?.ruleType?.ruleFormat?.levels?.size();j++){
+            if(data?.templateConfig?.rules[i]?.ruleType?.ruleFormat?.levels[j]?.startingValue){
+              ruleset?.templateConfig?.rules[i]?.ruleType?.ruleFormat?.levels[j]?.startingValue = Integer.parseInt(data?.templateConfig?.rules[i]?.ruleType?.ruleFormat?.levels[j]?.startingValue)
+            }
+          }
+        }
+      }
+    }
+
     ArrayList<InternalPiece> result = pieceGenerationService.createPiecesTransient(ruleset, LocalDate.parse(data.startDate))
     respond result
   }
 
   def generatePredictedPieces() {
     JSONObject data = request.JSON
-    SerialRuleset ruleset = SerialRuleset.get(data?.ruleset?.id)
+    SerialRuleset ruleset = SerialRuleset.get(data?.id)
+
+    if(ruleset?.templateConfig?.rules?.size()){
+      for(int i=0;i<ruleset?.templateConfig?.rules?.size();i++){
+        if(ruleset?.templateConfig?.rules[i]?.ruleType?.templateMetadataRuleFormat?.value == 'enumeration_numeric'){
+          for(int j=0;j<ruleset?.templateConfig?.rules[i]?.ruleType?.ruleFormat?.levels?.size();j++){
+            if(data?.templateConfig?.rules[i]?.ruleType?.ruleFormat?.levels[j]?.startingValue){
+              ruleset?.templateConfig?.rules[i]?.ruleType?.ruleFormat?.levels[j]?.startingValue = Integer.parseInt(data?.templateConfig?.rules[i]?.ruleType?.ruleFormat?.levels[j]?.startingValue)
+            }
+          }
+        }
+      }
+    }
+
     ArrayList<InternalPiece> ips = pieceGenerationService.createPiecesTransient(ruleset, LocalDate.parse(data.startDate))
 
     PredictedPieceSet pps = new PredictedPieceSet([

--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationNumericLevelTMRF.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationNumericLevelTMRF.groovy
@@ -45,7 +45,6 @@ class EnumerationNumericLevelTMRF implements MultiTenant<EnumerationNumericLevel
     owner(nullable:false, blank:false);
     index nullable: false
     units nullable: false
-    startingValue bindable: true
     format nullable: false
     sequence nullable: false
     internalNote nullable: true


### PR DESCRIPTION
Updated how starting values are binded within predicted piece set generation to ensure results are correctly saved