### PR TITLE
build: Added orders optional dependency

### DIFF
--- a/service/src/main/okapi/ModuleDescriptor-template.json
+++ b/service/src/main/okapi/ModuleDescriptor-template.json
@@ -143,6 +143,10 @@
   "requires":[
   ],
   "optional":[
+    {
+      "id": "orders",
+      "version": "12.0"
+    }
   ],
   "permissionSets": [
     {


### PR DESCRIPTION
Added optional dependency on mod-orders to the mod-serials-management module descriptor

[MODSER-12](https://folio-org.atlassian.net/browse/MODSER-12)