### PR TITLE
UISER-20: Extend API documentation

### DIFF
--- a/openapi/serials-management.yaml
+++ b/openapi/serials-management.yaml
@@ -33,12 +33,30 @@ paths:
                   - $ref: '#/components/schemas/RefDataResultsArray'
         '400':
           description: Bad request error
-        '404':
-          description: Not found
+        '403':
+          description: Forbidden
+        '500':
+          description: Internal server error
+    post:
+      summary: Create new reference data
+      operationId: createRefData
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RefDataCategory'
+        required: true
+      responses:
+        '201':
+          description: Created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HttpError'
+                $ref: '#/components/schemas/RefDataCategory'
+        '400':
+          description: Bad request error
+        '403':
+          description: Forbidden
         '500':
           description: Internal server error
   /serials-management/serials:
@@ -60,10 +78,12 @@ paths:
             application/json:
               schema:
                 oneOf:
-                  - $ref: '#/components/schemas/serialResults'
-                  - $ref: '#/components/schemas/serialResultsArray'
+                  - $ref: '#/components/schemas/SerialResults'
+                  - $ref: '#/components/schemas/SerialResultsArray'
         '400':
           description: Bad request error
+        '403':
+          description: Forbidden
         '500':
           description: Internal server error
     post:
@@ -77,16 +97,16 @@ paths:
         description: requestBody description
         required: true
       responses:
-        '200':
-          description: OK
+        '201':
+          description: Created
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Serial'
         '400':
           description: Bad request error
-        '404':
-          description: Not found error
+        '403':
+          description: Forbidden
         '500':
           description: Internal server error
   /serials-management/serials/{uuid}:
@@ -110,8 +130,14 @@ paths:
                 $ref: '#/components/schemas/Serial'
         '400':
           description: Bad request error
+        '403':
+          description: Forbidden
         '404':
           description: Not found error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HttpError'
         '500':
           description: Internal server error
     put:
@@ -148,7 +174,59 @@ paths:
                 $ref: '#/components/schemas/HttpError'
         '500':
           description: Internal server error
+    delete:
+      summary: Delete a specified serial record
+      operationId: deleteSerial
+      parameters:
+        - name: uuid
+          in: path
+          description: The uuid of the serial record to be deleted
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '204':
+          description: No content
+        '400':
+          description: Bad request error
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HttpError'
+        '500':
+          description: Internal server error
   /serials-management/rulesets:
+    get:
+      summary: Get a set of ruleset records
+      operationId: getRulesets
+      parameters:
+        - $ref: '#/components/parameters/filters'
+        - $ref: '#/components/parameters/match'
+        - $ref: '#/components/parameters/term'
+        - $ref: '#/components/parameters/sort'
+        - $ref: '#/components/parameters/stats'
+        - $ref: '#/components/parameters/perPage'
+        - $ref: '#/components/parameters/offset'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/SerialRulesetResults'
+                  - $ref: '#/components/schemas/SerialRulesetResultsArray'
+        '400':
+          description: Bad request error
+        '403':
+          description: Forbidden
+        '500':
+          description: Internal server error
     post:
       summary: Create ruleset record
       operationId: postRuleset
@@ -160,14 +238,16 @@ paths:
         description: Ruleset JSON
         required: true
       responses:
-        '200':
-          description: OK
+        '201':
+          description: Created
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/serialRuleset'
         '400':
           description: Bad request error
+        '403':
+          description: Forbidden
         '500':
           description: Internal server error
   /serials-management/predictedPieces:
@@ -193,6 +273,8 @@ paths:
                   - $ref: '#/components/schemas/PredictedPieceSetResultsArray'
         '400':
           description: Bad request error
+        '403':
+          description: Forbidden
         '500':
           description: Internal server error
   /serials-management/predictedPieces/{uuid}:
@@ -216,6 +298,8 @@ paths:
                 $ref: '#/components/schemas/PredictedPieceSet'
         '400':
           description: Bad request error
+        '403':
+          description: Forbidden
         '404':
           description: Not found error
           content:
@@ -234,20 +318,16 @@ paths:
             schema:
               $ref: '#/components/schemas/serialRuleset'
       responses:
-        '200':
-          description: OK
+        '201':
+          description: Created
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/PredictedPieceSet'
         '400':
           description: Bad request error
-        '404':
-          description: Not found error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HttpError'
+        '403':
+          description: Forbidden
         '500':
           description: Internal server error
   /serials-management/predictedPieces/create:
@@ -260,20 +340,16 @@ paths:
             schema:
               $ref: '#/components/schemas/serialRuleset'
       responses:
-        '200':
-          description: OK
+        '201':
+          description: Created
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/PredictedPieceSet'
         '400':
           description: Bad request error
-        '404':
-          description: Not found error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HttpError'
+        '403':
+          description: Forbidden
         '500':
           description: Internal server error
 components:
@@ -379,15 +455,6 @@ components:
           type: integer
         totalRecords:
           type: integer
-    HttpError:
-      type: object
-      properties:
-        message:
-          type: string
-        error:
-          type: integer
-        path:
-          type: string
     SerialOrderLine:
       type: object
       properties:
@@ -796,11 +863,11 @@ components:
           type: string
         owner:
           $ref: '#/components/schemas/Serial'
-    serialResults:
+    SerialResults:
       type: array
       items:
         $ref: '#/components/schemas/Serial'
-    serialResultsArray:
+    SerialResultsArray:
       type: object
       required:
         - results
@@ -809,6 +876,40 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Serial'
+        meta:
+          type: object
+        page:
+          type: integer
+        pageSize:
+          type: integer
+        total:
+          type: integer
+        totalPages:
+          type: integer
+        totalRecords:
+          type: integer
+    HttpError:
+      type: object
+      properties:
+        message:
+          type: string
+        error:
+          type: integer
+        path:
+          type: string
+    SerialRulesetResults:
+      type: array
+      items:
+        $ref: '#/components/schemas/SerialRuleset'
+    SerialRulesetResultsArray:
+      type: object
+      required:
+        - results
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/SerialRulesetResults'
         meta:
           type: object
         page:

--- a/openapi/serials-management.yaml
+++ b/openapi/serials-management.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   version: 1.0.0
   title: Folio Serials Management
@@ -13,7 +13,7 @@ paths:
   /serials-management/refdata:
     get:
       operationId: getRefData
-      summary: Returns list of reference data values for specified domain
+      summary: Get a set of reference data categories and values
       parameters:
         - $ref: '#/components/parameters/filters'
         - $ref: '#/components/parameters/match'
@@ -57,6 +57,133 @@ paths:
           description: Bad request error
         '403':
           description: Forbidden
+        '500':
+          description: Internal server error
+  /serials-management/refdata/{uuid}:
+    get:
+      summary: Get a specified reference data category
+      operationId: getRefDataCategory
+      parameters:
+        - name: uuid
+          in: path
+          description: The uuid of the reference data category to be fetched
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RefDataCategory'
+        '400':
+          description: Bad request error
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HttpError'
+        '500':
+          description: Internal server error
+    put:
+      summary: Update reference data category
+      operationId: putRefDataCategory
+      parameters:
+        - name: uuid
+          in: path
+          description: The uuid of the reference data category to be put
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RefDataCategory'
+        description: requestBody description
+        required: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RefDataCategory'
+        '400':
+          description: Bad request error
+        '404':
+          description: Not found error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HttpError'
+        '500':
+          description: Internal server error
+    delete:
+      summary: Delete a specified reference data category
+      operationId: deleteRefDataCategory
+      parameters:
+        - name: uuid
+          in: path
+          description: The uuid of the reference data category to be deleted
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '204':
+          description: No content
+        '400':
+          description: Bad request error
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HttpError'
+        '500':
+          description: Internal server error
+  /serials-management/refdata/{domain}/{property}:
+    get:
+      summary: Get a specified reference data property
+      operationId: getReferenceDataPropertybyDomainandField
+      parameters:
+        - name: domain
+          in: path
+          description: The DomainClass of the reference data category to which the property belongs
+          required: true
+          schema:
+            type: string
+        - name: property
+          in: path
+          description: The FieldName of the reference data property to be fetched
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RefData'
+        '400':
+          description: Bad request error
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HttpError'
         '500':
           description: Internal server error
   /serials-management/serials:
@@ -248,6 +375,63 @@ paths:
           description: Bad request error
         '403':
           description: Forbidden
+        '500':
+          description: Internal server error
+  /serials-management/rulesets/{uuid}:
+    get:
+      summary: Get a specified ruleset
+      operationId: getRuleset
+      parameters:
+        - name: uuid
+          in: path
+          description: The uuid of the ruleset record to be fetched
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SerialRuleset'
+        '400':
+          description: Bad request error
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HttpError'
+        '500':
+          description: Internal server error
+    delete:
+      summary: Delete a specified ruleset
+      operationId: deleteRuleset
+      parameters:
+        - name: uuid
+          in: path
+          description: The uuid of the ruleset to be deleted
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '204':
+          description: No content
+        '400':
+          description: Bad request error
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HttpError'
         '500':
           description: Internal server error
   /serials-management/predictedPieces:
@@ -455,6 +639,15 @@ components:
           type: integer
         totalRecords:
           type: integer
+    HttpError:
+      type: object
+      properties:
+        message:
+          type: string
+        error:
+          type: integer
+        path:
+          type: string
     SerialOrderLine:
       type: object
       properties:
@@ -888,15 +1081,6 @@ components:
           type: integer
         totalRecords:
           type: integer
-    HttpError:
-      type: object
-      properties:
-        message:
-          type: string
-        error:
-          type: integer
-        path:
-          type: string
     SerialRulesetResults:
       type: array
       items:


### PR DESCRIPTION
Adds endpoints:

- /serials-management/refdata/{uuid} GET
- /serials-management/refdata POST
- /serials-management/refdata/{uuid} PUT
- /serials-management/refdata/{uuid} DELETE
- /serials-management/refdata/{domain}/{property} GET
- /serials-management/serials/{uuid} DELETE
- /serials-management/rulesets GET
- /serials-management/rulesets/{uuid} GET
- /serials-management/rulesets/{uuid} DELETE

Corrects some response errors and describes 404 responses more fully