### PR TITLE
UISER-99/88: Starting values ordering and missing uses

### DIFF
--- a/service/grails-app/controllers/org/olf/PredictedPieceSetController.groovy
+++ b/service/grails-app/controllers/org/olf/PredictedPieceSetController.groovy
@@ -34,9 +34,10 @@ class PredictedPieceSetController extends OkapiTenantAwareController<PredictedPi
   def generatePredictedPiecesTransient() {
     JSONObject data = request.JSON
     SerialRuleset ruleset = new SerialRuleset(data)
+    List<Map> startingValues = data?.startingValues ?: []
 
     ArrayList<InternalPiece> ips = pieceGenerationService.createPiecesTransient(ruleset, LocalDate.parse(data.startDate))
-    pieceLabellingService.setLabelsForInternalPieces(ips, ruleset?.templateConfig, data?.startingValues)
+    pieceLabellingService.setLabelsForInternalPieces(ips, ruleset?.templateConfig, startingValues)
 
     respond ips
   }
@@ -44,9 +45,10 @@ class PredictedPieceSetController extends OkapiTenantAwareController<PredictedPi
   def generatePredictedPieces() {
     JSONObject data = request.JSON
     SerialRuleset ruleset = SerialRuleset.get(data?.id)
+    List<Map> startingValues = data?.startingValues ?: []
 
     ArrayList<InternalPiece> ips = pieceGenerationService.createPiecesTransient(ruleset, LocalDate.parse(data.startDate))
-    pieceLabellingService.setLabelsForInternalPieces(ips, ruleset?.templateConfig, data?.startingValues)
+    pieceLabellingService.setLabelsForInternalPieces(ips, ruleset?.templateConfig, startingValues)
 
     PredictedPieceSet pps = new PredictedPieceSet([
       ruleset: ruleset,

--- a/service/grails-app/controllers/org/olf/PredictedPieceSetController.groovy
+++ b/service/grails-app/controllers/org/olf/PredictedPieceSetController.groovy
@@ -1,6 +1,7 @@
 package org.olf
 
 import org.olf.PieceGenerationService
+import org.olf.PieceLabellingService
 
 import org.olf.Serial
 import org.olf.SerialRuleset
@@ -27,36 +28,25 @@ class PredictedPieceSetController extends OkapiTenantAwareController<PredictedPi
     super(PredictedPieceSet)
   }
   PieceGenerationService pieceGenerationService
+  PieceLabellingService pieceLabellingService
 
-  // Starting values will be refactored soon so this is a placeholder to ensure they are passed through presently
-  private SerialRuleset handleStartingValues(SerialRuleset ruleset, JSONObject data){
-    if(ruleset?.templateConfig?.rules?.size()){
-        for(int i=0;i<ruleset?.templateConfig?.rules?.size();i++){
-          if(ruleset?.templateConfig?.rules[i]?.ruleType?.templateMetadataRuleFormat?.value == 'enumeration_numeric'){
-            for(int j=0;j<ruleset?.templateConfig?.rules[i]?.ruleType?.ruleFormat?.levels?.size();j++){
-              if(data?.templateConfig?.rules?.getAt(i)?.ruleType?.ruleFormat?.levels?.getAt(j)?.startingValue){
-                ruleset?.templateConfig?.rules[i]?.ruleType?.ruleFormat?.levels[j]?.startingValue = Integer.parseInt(data?.templateConfig?.rules[i]?.ruleType?.ruleFormat?.levels[j]?.startingValue)
-              }
-            }
-          }
-        }
-      }
-    return ruleset  
-  }
   // This takes in a JSON shape and outputs predicted pieces without saving domain objects
   def generatePredictedPiecesTransient() {
     JSONObject data = request.JSON
     SerialRuleset ruleset = new SerialRuleset(data)
 
-    ArrayList<InternalPiece> result = pieceGenerationService.createPiecesTransient(handleStartingValues(ruleset, data), LocalDate.parse(data.startDate))
-    respond result
+    ArrayList<InternalPiece> ips = pieceGenerationService.createPiecesTransient(ruleset, LocalDate.parse(data.startDate))
+    pieceLabellingService.setLabelsForInternalPieces(ips, ruleset?.templateConfig, data?.startingValues)
+
+    respond ips
   }
 
   def generatePredictedPieces() {
     JSONObject data = request.JSON
     SerialRuleset ruleset = SerialRuleset.get(data?.id)
 
-    ArrayList<InternalPiece> ips = pieceGenerationService.createPiecesTransient(handleStartingValues(ruleset, data), LocalDate.parse(data.startDate))
+    ArrayList<InternalPiece> ips = pieceGenerationService.createPiecesTransient(ruleset, LocalDate.parse(data.startDate))
+    pieceLabellingService.setLabelsForInternalPieces(ips, ruleset?.templateConfig, data?.startingValues)
 
     PredictedPieceSet pps = new PredictedPieceSet([
       ruleset: ruleset,

--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRule/EnumerationTemplateMetadataRule.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRule/EnumerationTemplateMetadataRule.groovy
@@ -39,12 +39,10 @@ public class EnumerationTemplateMetadataRule extends TemplateMetadataRuleType im
     ruleFormat nullable: false, validator: TemplateMetadataRuleTypeHelpers.ruleFormatValidator
   }
 
-  public static EnumerationTemplateMetadata handleType(TemplateMetadataRule rule, LocalDate date, int index) {
+  public static EnumerationTemplateMetadata handleType(TemplateMetadataRule rule, LocalDate date, int index, Map startingValues) {
     final Pattern RGX_RULE_FORMAT = Pattern.compile('_([a-z])')
     String ruleFormatClassString = RGX_RULE_FORMAT.matcher(rule?.ruleType?.templateMetadataRuleFormat?.value).replaceAll { match -> match.group(1).toUpperCase() }
-    println(ruleFormatClassString)
-    println(rule?.index)
     Class<? extends TemplateMetadataRuleFormat> rfc = Class.forName("org.olf.templateConfig.templateMetadataRuleFormat.${ruleFormatClassString.capitalize()}TMRF")
-    return rfc.handleFormat(rule, date, index)
+    return rfc.handleFormat(rule, date, index, startingValues)
   }
 }

--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRule/EnumerationTemplateMetadataRule.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRule/EnumerationTemplateMetadataRule.groovy
@@ -42,6 +42,8 @@ public class EnumerationTemplateMetadataRule extends TemplateMetadataRuleType im
   public static EnumerationTemplateMetadata handleType(TemplateMetadataRule rule, LocalDate date, int index) {
     final Pattern RGX_RULE_FORMAT = Pattern.compile('_([a-z])')
     String ruleFormatClassString = RGX_RULE_FORMAT.matcher(rule?.ruleType?.templateMetadataRuleFormat?.value).replaceAll { match -> match.group(1).toUpperCase() }
+    println(ruleFormatClassString)
+    println(rule?.index)
     Class<? extends TemplateMetadataRuleFormat> rfc = Class.forName("org.olf.templateConfig.templateMetadataRuleFormat.${ruleFormatClassString.capitalize()}TMRF")
     return rfc.handleFormat(rule, date, index)
   }

--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationNumericTMRF.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationNumericTMRF.groovy
@@ -53,15 +53,14 @@ public class EnumerationNumericTMRF extends TemplateMetadataRuleFormat implement
     return roman 
   }  
 
-  public static EnumerationTemplateMetadata handleFormat (TemplateMetadataRule rule, LocalDate date, int index){
+  public static EnumerationTemplateMetadata handleFormat (TemplateMetadataRule rule, LocalDate date, int index, Map startingValues){
     ArrayList<EnumerationNumericLevelTMRF> enltmrfArray = rule?.ruleType?.ruleFormat?.levels?.sort { it?.index }
     ArrayList<EnumerationTemplateMetadataLevel> result = []
     Integer adjustedIndex = 0
     Integer divisor = 1
     for(int i=enltmrfArray?.size()-1; i>=0; i--){
-
-      if(enltmrfArray[i]?.startingValue !== null){
-        adjustedIndex = adjustedIndex + ((enltmrfArray[i]?.startingValue - 1)*divisor)
+      if(startingValues?.levels?.getAt(i)?.value !== null){
+        adjustedIndex = adjustedIndex + ((startingValues?.levels.getAt(i)?.value as Integer - 1)*divisor)
       }
 
       Integer value = 0

--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationTextualTMRF.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationTextualTMRF.groovy
@@ -38,7 +38,7 @@ public class EnumerationTextualTMRF extends TemplateMetadataRuleFormat implement
     }
   }
 
-  public static EnumerationTemplateMetadata handleFormat (TemplateMetadataRule rule, LocalDate date, int index){
+  public static EnumerationTemplateMetadata handleFormat (TemplateMetadataRule rule, LocalDate date, int index, Map startingValues){
     String result = findResultIndex(rule, index + 1)
     return new EnumerationTemplateMetadata([value: result])
   }

--- a/service/grails-app/services/org/olf/PieceGenerationService.groovy
+++ b/service/grails-app/services/org/olf/PieceGenerationService.groovy
@@ -207,10 +207,6 @@ public class PieceGenerationService {
       }
     }
     
-    if (!!ruleset?.templateConfig) {
-      pieceLabellingService.setLabelsForInternalPieces(internalPieces, ruleset?.templateConfig)
-    }
-
     return internalPieces
   }
 }

--- a/service/grails-app/services/org/olf/PieceLabellingService.groovy
+++ b/service/grails-app/services/org/olf/PieceLabellingService.groovy
@@ -31,7 +31,7 @@ public class PieceLabellingService {
 
 
   // This needs to take in an individual piece and ooutput a String label
-  public String generateTemplatedLabelForPiece(InternalPiece piece, ArrayList<InternalPiece> internalPieces, TemplateConfig templateConfig, Map startingValues) { 
+  public String generateTemplatedLabelForPiece(InternalPiece piece, ArrayList<InternalPiece> internalPieces, TemplateConfig templateConfig, List<Map> startingValues) { 
     Template template = hte.createTemplate(templateConfig.templateString);
     // Template template = hte.createTemplate("EA {{chronology1.year}} {{chronologyArray.0.year}} {{test}}")
 
@@ -53,7 +53,7 @@ public class PieceLabellingService {
     }
   }
 
-  public void setLabelsForInternalPieces(ArrayList<InternalPiece> internalPieces, TemplateConfig templateConfig, Map startingValues) {
+  public void setLabelsForInternalPieces(ArrayList<InternalPiece> internalPieces, TemplateConfig templateConfig, List<Map> startingValues) {
     ListIterator<InternalPiece> iterator = internalPieces?.listIterator()
     while(iterator.hasNext()){
       InternalPiece currentPiece = iterator.next()
@@ -155,7 +155,7 @@ public class PieceLabellingService {
     return chronologyTemplateMetadataArray
   }
 
-  public ArrayList<EnumerationTemplateMetadata> generateEnumerationMetadata(StandardTemplateMetadata standardTM, Set<TemplateMetadataRule> templateMetadataRules, Map startingValues) {
+  public ArrayList<EnumerationTemplateMetadata> generateEnumerationMetadata(StandardTemplateMetadata standardTM, Set<TemplateMetadataRule> templateMetadataRules, List<Map> startingValues) {
     ArrayList<EnumerationTemplateMetadata> enumerationTemplateMetadataArray = []
     Iterator<TemplateMetadataRule> iterator = templateMetadataRules?.iterator()
     while(iterator?.hasNext()){
@@ -163,7 +163,8 @@ public class PieceLabellingService {
       String templateMetadataType = RGX_METADATA_RULE_TYPE.matcher(currentMetadataRule?.templateMetadataRuleType?.value).replaceAll { match -> match.group(1).toUpperCase() }
       if(templateMetadataType == 'enumeration'){
         Class<? extends TemplateMetadataRuleType> tmrte = Class.forName("org.olf.templateConfig.templateMetadataRule.${templateMetadataType.capitalize()}TemplateMetadataRule")
-        EnumerationTemplateMetadata enumerationTemplateMetadata = tmrte.handleType(currentMetadataRule, standardTM.date, standardTM.index)
+        Map ruleStartingValues = startingValues.getAt(currentMetadataRule?.index)
+        EnumerationTemplateMetadata enumerationTemplateMetadata = tmrte.handleType(currentMetadataRule, standardTM.date, standardTM.index, ruleStartingValues)
 
         enumerationTemplateMetadataArray << enumerationTemplateMetadata
       }


### PR DESCRIPTION
This PR covers multiple tickets:
- Template does not always get data from labels or levels in the same order
- Level 1 number not used correctly in predicted piece preview from Create Publication Pattern

The starting values have now been parsed out into their own array as opposed to the original usage of transient values within the domain models

[UISER-99](https://folio-org.atlassian.net/browse/UISER-99), [UISER-88](https://folio-org.atlassian.net/browse/UISER-88)