### PR TITLE
fix: Support using different languages for chronologies when generating predicted pieces

### DIFF
--- a/service/grails-app/controllers/org/olf/LocalesController.groovy
+++ b/service/grails-app/controllers/org/olf/LocalesController.groovy
@@ -1,0 +1,27 @@
+package org.olf
+
+import com.k_int.okapi.OkapiTenantAwareController
+
+import grails.gorm.multitenancy.CurrentTenant
+import groovy.json.JsonOutput
+import groovy.util.logging.Slf4j
+
+import java.util.regex.Pattern
+import java.util.Locale
+
+@Slf4j
+@CurrentTenant
+class LocalesController {
+
+  def getLocales() {
+    Locale[] locales = Locale.getAvailableLocales();
+    ArrayList<Map> localesList = locales.collect { Locale locale ->
+      {[ 
+        label: locale.getDisplayName(),
+        value: locale.toString()
+      ]}
+    }.sort { it.label }
+    
+    respond localesList
+  }
+ }

--- a/service/grails-app/controllers/org/olf/UrlMappings.groovy
+++ b/service/grails-app/controllers/org/olf/UrlMappings.groovy
@@ -10,6 +10,8 @@ class UrlMappings {
         "/$domain/$property" (controller: 'refdata', action: 'lookup', method: 'GET')
       }
     }
+    
+    "/serials-management/locales" (controller: 'locales', action: 'getLocales', method: 'GET')
 
     "/serials-management/serials" (resources: 'serial')
 

--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRule/ChronologyTemplateMetadataRule.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRule/ChronologyTemplateMetadataRule.groovy
@@ -6,6 +6,7 @@ import org.olf.internalPiece.templateMetadata.ChronologyTemplateMetadata
 import java.util.regex.Pattern
 
 import java.time.LocalDate
+import java.util.Locale
 
 import grails.gorm.MultiTenant
 import grails.databinding.BindUsing
@@ -21,6 +22,8 @@ public class ChronologyTemplateMetadataRule extends TemplateMetadataRuleType imp
   @Defaults(['Chronology Date', 'Chronology Month', 'Chronology Year'])
   RefdataValue templateMetadataRuleFormat
 
+  String ruleLocale = 'en'
+
   @BindUsing({ TemplateMetadataRuleType obj, SimpleMapDataBindingSource source ->
 		TemplateMetadataRuleTypeHelpers.doRuleFormatBinding(obj, source)
   })
@@ -33,11 +36,13 @@ public class ChronologyTemplateMetadataRule extends TemplateMetadataRuleType imp
 
   static mapping = {
     templateMetadataRuleFormat column: 'ctmr_template_metadata_rule_format_fk'
+    ruleLocale column: 'ctmr_rule_locale'
     ruleFormat cascade: 'all-delete-orphan'
   }
 
   static constraints = {
     templateMetadataRuleFormat nullable: false
+    ruleLocale nullable: false
     ruleFormat nullable: false, validator: TemplateMetadataRuleTypeHelpers.ruleFormatValidator
   }
 

--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/ChronologyDateTMRF.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/ChronologyDateTMRF.groovy
@@ -8,6 +8,8 @@ import org.olf.internalPiece.templateMetadata.ChronologyTemplateMetadata
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
+import java.util.Locale
+
 import com.k_int.web.toolkit.refdata.CategoryId
 import com.k_int.web.toolkit.refdata.Defaults
 import com.k_int.web.toolkit.refdata.RefdataValue
@@ -77,28 +79,21 @@ public class ChronologyDateTMRF extends TemplateMetadataRuleFormat implements Mu
 		]
    
   public static ChronologyTemplateMetadata handleFormat(TemplateMetadataRule rule, LocalDate date, int index) {
+    Locale locale = new Locale(rule?.ruleType?.ruleLocale)
     ChronologyDateTMRF tmrf = rule?.ruleType?.ruleFormat
     // TODO Dont handle if not a chronology rule
-		String weekday = date.format(DateTimeFormatter.ofPattern(weekdayFormatTransform.get(tmrf?.weekdayFormat?.value)))
+		String weekday = date.format(DateTimeFormatter.ofPattern(weekdayFormatTransform.get(tmrf?.weekdayFormat?.value), locale))
 		if(tmrf?.weekdayFormat?.value.endsWith('upper')){
 			weekday = weekday.toUpperCase()
 		}
 
-    // FIXME IMPLEMENT THIS PROPERLY
-    Set<Locale> allLanguages = new HashSet<Locale>();
-    String[] languages = Locale.getISOLanguages();
-    for (int i = 0; i < languages.length; i++){
-      Locale loc = new Locale(languages[i]);
-      allLanguages.add(loc);
-    }
-
-		String monthDay = date.format(DateTimeFormatter.ofPattern('d'))
+		String monthDay = date.format(DateTimeFormatter.ofPattern('d', locale))
 		if(tmrf?.monthDayFormat?.value == 'ordinal'){
 			monthDay = monthDay + getDayOfMonthSuffix(Integer.parseInt(monthDay))
 		}
 
-    String month = date.format(DateTimeFormatter.ofPattern(monthFormatTransform.get(tmrf?.monthFormat?.value)));
-  	String year = date.format(DateTimeFormatter.ofPattern(yearFormatTransform.get(tmrf?.yearFormat?.value)));
+    String month = date.format(DateTimeFormatter.ofPattern(monthFormatTransform.get(tmrf?.monthFormat?.value), locale));
+  	String year = date.format(DateTimeFormatter.ofPattern(yearFormatTransform.get(tmrf?.yearFormat?.value), locale));
 
   	return new ChronologyTemplateMetadata([weekday: weekday, monthDay: monthDay, month: month, year: year, templateMetadataRule: rule])
   }  

--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/ChronologyMonthTMRF.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/ChronologyMonthTMRF.groovy
@@ -8,6 +8,8 @@ import grails.gorm.MultiTenant
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
+import java.util.Locale
+
 import com.k_int.web.toolkit.refdata.CategoryId
 import com.k_int.web.toolkit.refdata.Defaults
 import com.k_int.web.toolkit.refdata.RefdataValue
@@ -33,6 +35,7 @@ public class ChronologyMonthTMRF extends TemplateMetadataRuleFormat implements M
   }
 
   public static ChronologyTemplateMetadata handleFormat(TemplateMetadataRule rule, LocalDate date, int index) {
+    Locale locale = new Locale(rule?.ruleType?.ruleLocale)
     ChronologyMonthTMRF tmrf = rule?.ruleType?.ruleFormat
     Map<String, String> getYearFormat = [
     	slice: 'yy',
@@ -45,8 +48,8 @@ public class ChronologyMonthTMRF extends TemplateMetadataRuleFormat implements M
       number: 'MM'
    	]
     
- 	  DateTimeFormatter monthFormatter = DateTimeFormatter.ofPattern(getMonthFormat.get(tmrf?.monthFormat?.value));
-	  DateTimeFormatter yearFormatter = DateTimeFormatter.ofPattern(getYearFormat.get(tmrf?.yearFormat?.value));
+ 	  DateTimeFormatter monthFormatter = DateTimeFormatter.ofPattern(getMonthFormat.get(tmrf?.monthFormat?.value), locale);
+	  DateTimeFormatter yearFormatter = DateTimeFormatter.ofPattern(getYearFormat.get(tmrf?.yearFormat?.value), locale);
 
     String month = date.format(monthFormatter);
   	String year = date.format(yearFormatter);

--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/ChronologyYearTMRF.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/ChronologyYearTMRF.groovy
@@ -27,13 +27,15 @@ public class ChronologyYearTMRF extends TemplateMetadataRuleFormat implements Mu
   }
 
   public static ChronologyTemplateMetadata handleFormat(TemplateMetadataRule rule, LocalDate date, int index) {
+    println(rule)
+    Locale locale = new Locale(rule?.ruleType?.ruleLocale)
 		ChronologyYearTMRF tmrf = rule?.ruleType?.ruleFormat
     Map<String, String> getYearFormat = [
     	slice: 'yy',
      	full: 'yyyy',
    	]
 
-	  DateTimeFormatter yearFormatter = DateTimeFormatter.ofPattern(getYearFormat.get(tmrf?.yearFormat?.value));
+	  DateTimeFormatter yearFormatter = DateTimeFormatter.ofPattern(getYearFormat.get(tmrf?.yearFormat?.value), locale);
 
   	String year = date.format(yearFormatter);
 

--- a/service/grails-app/migrations/module-tenant-changelog.groovy
+++ b/service/grails-app/migrations/module-tenant-changelog.groovy
@@ -1,4 +1,5 @@
 databaseChangeLog = {
   include file: 'initial-customisations.groovy'
   include file: 'create-mod-serials-management.groovy'
+  include file: 'update-mod-serials-management-1-1.groovy'
 }

--- a/service/grails-app/migrations/update-mod-serials-management-1-1.groovy
+++ b/service/grails-app/migrations/update-mod-serials-management-1-1.groovy
@@ -1,0 +1,7 @@
+databaseChangeLog = {
+  changeSet(author: "Jack-Golding (manual)", id: "20240416-1325-001") {
+    addColumn(tableName: "chronology_template_metadata_rule") {
+      column(name: "ctmr_rule_locale", type: "VARCHAR(36)") { constraints(nullable: "true") }
+    }
+  }
+}

--- a/service/src/main/okapi/ModuleDescriptor-template.json
+++ b/service/src/main/okapi/ModuleDescriptor-template.json
@@ -115,6 +115,11 @@
           "methods": ["POST"],
           "pathPattern": "/serials-management/predictedPieces/create",
           "permissionsRequired": [ "serials-management.predictedPieces.edit" ]
+        },
+        {
+          "methods": ["GET"],
+          "pathPattern": "/serials-management/locales",
+          "permissionsRequired": [ "serials-management.refdata.collection.get" ]
         }
       ]
     },


### PR DESCRIPTION
Added ruleLocale field to handle using a 2 letter locale value when generating chronologies

UISER-113