### PR TITLE
fix: Fixed ChronologyUCTMT constraints field

### DIFF
--- a/service/grails-app/domain/org/olf/internalPiece/templateMetadata/ChronologyUCTMT.groovy
+++ b/service/grails-app/domain/org/olf/internalPiece/templateMetadata/ChronologyUCTMT.groovy
@@ -13,7 +13,7 @@ public class ChronologyUCTMT extends UserConfiguredTemplateMetadataType implemen
   String month
   String year
 
-  static constraint = {
+  static constraints = {
     weekday nullable: true
     monthDay nullable: true
     month nullable: true


### PR DESCRIPTION
Field was previously called "constraint" caused to saving errors

[MODSER-37](https://folio-org.atlassian.net/browse/MODSER-37)