### PR TITLE
fix: EnumerationLevelUCTMT value handling

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -164,6 +164,7 @@ dependencies {
 
 	implementation 'uk.co.cacoethes:groovy-handlebars-engine:0.2'
   implementation 'com.github.jknack:handlebars-helpers:4.3.1'
+	implementation 'com.github.fracpete:romannumerals4j:0.0.1'
 
 	/* ---- Custom non profile deps ---- */
   implementation 'org.apache.kafka:kafka-clients:3.7.0'

--- a/service/grails-app/domain/org/olf/internalPiece/templateMetadata/EnumerationLevelUCTMT.groovy
+++ b/service/grails-app/domain/org/olf/internalPiece/templateMetadata/EnumerationLevelUCTMT.groovy
@@ -9,7 +9,11 @@ import com.k_int.web.toolkit.refdata.RefdataValue
 public class EnumerationLevelUCTMT implements MultiTenant<EnumerationLevelUCTMT> {
   String id
   String value
+  Integer rawValue
   Integer index
+
+  // Roman, Number, Ordinal - Matching EnumerationNumericLevelTMRF
+  RefdataValue valueFormat
 
   static belongsTo = [
     owner: EnumerationUCTMT
@@ -21,11 +25,15 @@ public class EnumerationLevelUCTMT implements MultiTenant<EnumerationLevelUCTMT>
     version column: 'eluctmt_version'
     index column: 'eluctmt_index'
     value column: 'eluctmt_value'
+    rawValue column: 'eluctmt_raw_value'
+    valueFormat column: 'eluctmt_value_format_fk'
   }
 
   static constraints = {
     owner(nullable:false, blank:false);
     index nullable: false
     value nullable: false
+    rawValue nullable: false
+    valueFormat nullable: false
   }
 }

--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationNumericLevelTMRF.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationNumericLevelTMRF.groovy
@@ -12,7 +12,6 @@ class EnumerationNumericLevelTMRF implements MultiTenant<EnumerationNumericLevel
 
   Integer index
   Integer units
-  // Integer startingValue
 
   @CategoryId(value="EnumerationNumericLevelTMRF.Format", defaultInternal=true)
   @Defaults(['Ordinal', 'Number', 'Roman'])
@@ -23,8 +22,6 @@ class EnumerationNumericLevelTMRF implements MultiTenant<EnumerationNumericLevel
   RefdataValue sequence
 
   String internalNote
-
-  // static transients = ['startingValue']
 
   static belongsTo = [
     owner: EnumerationNumericTMRF

--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationNumericLevelTMRF.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationNumericLevelTMRF.groovy
@@ -12,7 +12,7 @@ class EnumerationNumericLevelTMRF implements MultiTenant<EnumerationNumericLevel
 
   Integer index
   Integer units
-  Integer startingValue
+  // Integer startingValue
 
   @CategoryId(value="EnumerationNumericLevelTMRF.Format", defaultInternal=true)
   @Defaults(['Ordinal', 'Number', 'Roman'])
@@ -24,7 +24,7 @@ class EnumerationNumericLevelTMRF implements MultiTenant<EnumerationNumericLevel
 
   String internalNote
 
-  static transients = ['startingValue']
+  // static transients = ['startingValue']
 
   static belongsTo = [
     owner: EnumerationNumericTMRF

--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationNumericTMRF.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationNumericTMRF.groovy
@@ -87,7 +87,12 @@ public class EnumerationNumericTMRF extends TemplateMetadataRuleFormat implement
       if(enltmrfArray[i]?.format?.value == 'roman'){
         stringValue = intToRoman(value)
       }
-      result.add([value: stringValue, index: i])
+      result.add([
+        value: stringValue,
+        rawValue: value,
+        valueFormat: enltmrfArray[i]?.format?.value,
+        index: i
+      ])
       divisor = enltmrfArray[i]?.units*divisor
     }
     return new EnumerationUCTMT([levels: result.reverse()])

--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationNumericTMRF.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationNumericTMRF.groovy
@@ -90,7 +90,7 @@ public class EnumerationNumericTMRF extends TemplateMetadataRuleFormat implement
       result.add([
         value: stringValue,
         rawValue: value,
-        valueFormat: enltmrfArray[i]?.format?.value,
+        valueFormat: enltmrfArray[i]?.format,
         index: i
       ])
       divisor = enltmrfArray[i]?.units*divisor

--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationNumericTMRF.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationNumericTMRF.groovy
@@ -12,6 +12,8 @@ import com.k_int.web.toolkit.refdata.CategoryId
 import com.k_int.web.toolkit.refdata.Defaults
 import com.k_int.web.toolkit.refdata.RefdataValue
 
+import com.github.fracpete.romannumerals4j.RomanNumeralFormat;
+
 public class EnumerationNumericTMRF extends TemplateMetadataRuleFormat implements MultiTenant<EnumerationNumericTMRF> {
   Set<EnumerationNumericLevelTMRF> levels
   
@@ -39,26 +41,16 @@ public class EnumerationNumericTMRF extends TemplateMetadataRuleFormat implement
     }
 	}
 
-  public static String intToRoman(int num){  
-    Integer[] values = [1000,900,500,400,100,90,50,40,10,9,5,4,1];  
-    String[] romanLetters = ["M","CM","D","CD","C","XC","L","XL","X","IX","V","IV","I"];  
-    String roman = '' 
-    for(int i=0;i<values.length;i++){  
-      while(num >= values[i]){  
-        num = num - values[i];  
-        roman += romanLetters[i];  
-      }  
-    } 
-
-    return roman 
-  }  
-
   public static EnumerationUCTMT handleFormat (TemplateMetadataRule rule, LocalDate date, int index, EnumerationUCTMT startingValues){
+    RomanNumeralFormat rnf = new RomanNumeralFormat();
+
     ArrayList<EnumerationNumericLevelTMRF> enltmrfArray = rule?.ruleType?.ruleFormat?.levels?.sort { it?.index }
     ArrayList<EnumerationLevelUCTMT> svArray = startingValues?.levels?.sort { it?.index }
     ArrayList<EnumerationLevelUCTMT> result = []
+
     Integer adjustedIndex = 0
     Integer divisor = 1
+
     for(int i=enltmrfArray?.size()-1; i>=0; i--){
       if(svArray?.getAt(i)?.value !== null){
         adjustedIndex = adjustedIndex + ((svArray.getAt(i)?.value as Integer - 1)*divisor)
@@ -72,12 +64,12 @@ public class EnumerationNumericTMRF extends TemplateMetadataRuleFormat implement
       }
 
       if(enltmrfArray[i]?.sequence?.value == 'reset'){
-          if(value%enltmrfArray[i]?.units == 0){
-            value = enltmrfArray[i]?.units
-          }else{
-            value = value%enltmrfArray[i]?.units
-          }
+        if(value%enltmrfArray[i]?.units == 0){
+          value = enltmrfArray[i]?.units
+        }else{
+          value = value%enltmrfArray[i]?.units
         }
+      }
 
       String stringValue = value
       if(enltmrfArray[i]?.format?.value == 'ordinal'){
@@ -85,14 +77,16 @@ public class EnumerationNumericTMRF extends TemplateMetadataRuleFormat implement
       }
 
       if(enltmrfArray[i]?.format?.value == 'roman'){
-        stringValue = intToRoman(value)
+        stringValue = rnf.format(value)
       }
+
       result.add([
         value: stringValue,
         rawValue: value,
         valueFormat: enltmrfArray[i]?.format,
         index: i
       ])
+      
       divisor = enltmrfArray[i]?.units*divisor
     }
     return new EnumerationUCTMT([levels: result.reverse()])

--- a/service/grails-app/migrations/update-mod-serials-management-1-1.groovy
+++ b/service/grails-app/migrations/update-mod-serials-management-1-1.groovy
@@ -74,4 +74,11 @@ databaseChangeLog = {
       column(name: "next_piece_template_metadata_id", type: "VARCHAR(36)") { constraints(nullable: "false") }
     }
   }
+
+  changeSet(author: "Jack-Golding (manual)", id: "20240725-1425-001") {
+    addColumn(tableName: "enumeration_leveluctmt") {
+      column(name: "eluctmt_raw_value", type: "INTEGER") { constraints(nullable: "true") }
+      column(name: "eluctmt_value_format_fk", type: "VARCHAR(36)") { constraints(nullable: "true") }
+    }
+  }
 }

--- a/service/grails-app/services/org/olf/HousekeepingService.groovy
+++ b/service/grails-app/services/org/olf/HousekeepingService.groovy
@@ -85,9 +85,6 @@ class HousekeepingService {
     // Establish a database session in the context of the activated tenant. You can use GORM domain classes inside the closure
     Tenants.withId(tenantId) {
       AppSetting.withNewTransaction { status ->
-          cleanupEnumerationLevelMetadata();
-
-
         // Setup EnumerationTemplateMetadataRule refdata values
         RefdataValue.lookupOrCreate(
           "EnumerationTemplateMetadataRule.TemplateMetadataRuleFormat",
@@ -121,6 +118,8 @@ class HousekeepingService {
           "chronology_year",
           true
         )
+
+        cleanupEnumerationLevelMetadata();
       }
     }
   }

--- a/service/grails-app/services/org/olf/HousekeepingService.groovy
+++ b/service/grails-app/services/org/olf/HousekeepingService.groovy
@@ -53,7 +53,7 @@ class HousekeepingService {
     Pattern oridnalRegex = Pattern.compile("(?=.*st)|(?=.*nd)|(?=.*rd)|(?=.*th)")
 
     // Find all EnumerationLevelUCTMT of all format with missing rawValue/valueFormat
-    List<EnumerationLevelUCTMT> levelsMissingRawValue = EnumerationLevelUCTMT.executeQuery('''
+    List<EnumerationLevelUCTMT> incompleteLevels = EnumerationLevelUCTMT.executeQuery('''
       select eluctmt
       from EnumerationLevelUCTMT as eluctmt
       where (eluctmt.rawValue is null)

--- a/service/grails-app/services/org/olf/HousekeepingService.groovy
+++ b/service/grails-app/services/org/olf/HousekeepingService.groovy
@@ -1,12 +1,15 @@
 package org.olf
 
 import java.sql.ResultSet
+import java.util.regex.Pattern
 
 import javax.sql.DataSource
 
 import org.grails.datastore.mapping.core.exceptions.ConfigurationException
 import org.grails.orm.hibernate.HibernateDatastore
 import org.grails.plugins.databasemigration.liquibase.GrailsLiquibase
+
+import org.olf.internalPiece.templateMetadata.EnumerationLevelUCTMT
 
 import grails.core.GrailsApplication
 import grails.events.annotation.Subscriber
@@ -18,8 +21,6 @@ import com.k_int.web.toolkit.settings.AppSetting
 import com.k_int.web.toolkit.refdata.*
 import com.k_int.okapi.OkapiTenantResolver
 
-import org.olf.internalPiece.templateMetadata.EnumerationLevelUCTMT
-import java.util.regex.Pattern
 import com.github.fracpete.romannumerals4j.RomanNumeralFormat;
 
 

--- a/service/grails-app/views/enumerationLevelUCTMT/_enumerationLevelUCTMT.gson
+++ b/service/grails-app/views/enumerationLevelUCTMT/_enumerationLevelUCTMT.gson
@@ -2,5 +2,9 @@ import groovy.transform.*
 import org.olf.internalPiece.templateMetadata.EnumerationLevelUCTMT
 import groovy.transform.Field
 
+def should_expand = [
+  'valueFormat'
+]
+
 @Field EnumerationLevelUCTMT enumerationLevelUCTMT
-json g.render(enumerationLevelUCTMT, [excludes: ['owner']])
+json g.render(enumerationLevelUCTMT, [excludes: ['owner'], expand: should_expand])


### PR DESCRIPTION
Upon adding in the functionality to auto-populate fields based on previously generated predicted piece sets ([UISER-91](https://folio-org.atlassian.net/browse/UISER-91)), we found that it was being populated with the template string value as opposed to the number value it was actually meant to represent, to resolve this we've expanded the EnumerationLevelUCTMT domain model to include the raw value and value format