### PR TITLE
chore: Hibernate deprecation logging

### DIFF
--- a/service/grails-app/conf/logback-development.xml
+++ b/service/grails-app/conf/logback-development.xml
@@ -67,6 +67,10 @@
     <level value="WARN" />
   </logger>
 
+  <logger name="org.hibernate.orm.deprecation">
+    <level value="ERROR" />
+  </logger>
+
   <logger name="mod.directory">
     <level value="INFO" />
   </logger>

--- a/service/grails-app/conf/logback.xml
+++ b/service/grails-app/conf/logback.xml
@@ -67,6 +67,10 @@
     <level value="WARN" />
   </logger>
 
+  <logger name="org.hibernate.orm.deprecation">
+    <level value="ERROR" />
+  </logger>
+
   <logger name="mod.directory">
     <level value="INFO" />
   </logger>


### PR DESCRIPTION
Added hibernate deprecation logging to logback filies to fix excessive logging of "Hibernate's legacy org.hibernate.Criteria API is deprecated" warning