### PR TITLE
fix: Expanded time unit within omission rule

### DIFF
--- a/service/grails-app/views/omissionRule/_omissionRule.gson
+++ b/service/grails-app/views/omissionRule/_omissionRule.gson
@@ -5,6 +5,7 @@ import groovy.transform.Field
 import java.util.regex.Pattern
 
 def should_expand = [
+  'timeUnit',
   'patternType',
 ]
 


### PR DESCRIPTION
Fixed an issue in which the timeUnit refdata was not expanded within the omission rule view