### PR TITLE
UISER-153: Support edit for publication patterns

### DIFF
--- a/service/grails-app/controllers/org/olf/PredictedPieceSetController.groovy
+++ b/service/grails-app/controllers/org/olf/PredictedPieceSetController.groovy
@@ -81,6 +81,7 @@ class PredictedPieceSetController extends OkapiTenantAwareController<PredictedPi
       startDate: data?.startDate,
       firstPieceTemplateMetadata: firstPieceTemplateMetadata,
       nextPieceTemplateMetadata: nextPieceTemplateMetadata
+      // TODO Check that this should be a flush
     ]).save(flush: true, failOnError: true)
 
     respond pps

--- a/service/grails-app/controllers/org/olf/SerialRulesetController.groovy
+++ b/service/grails-app/controllers/org/olf/SerialRulesetController.groovy
@@ -56,6 +56,16 @@ class SerialRulesetController extends OkapiTenantAwareController<SerialRuleset> 
     respond result
   }
 
+  //Check to see if new ruleset is active, if it is, additionally set the current active ruleset to deprecated
+  private void activeRulesetCheck(SerialRuleset ruleset) {
+    if(ruleset?.rulesetStatus?.value == 'active'){
+      String activeRulesetId = serialRulesetService.findActive(ruleset?.owner?.id)
+      if(activeRulesetId){
+        serialRulesetService.updateRulesetStatus(activeRulesetId, 'deprecated')
+      }
+    }
+  }
+
   @Transactional
   def replaceAndDelete() {
     SerialRuleset.withTransaction {
@@ -78,13 +88,8 @@ class SerialRulesetController extends OkapiTenantAwareController<SerialRuleset> 
       }
       // New ruleset
       SerialRuleset ruleset = new SerialRuleset(data)
-      //Check to see if new ruleset is active, if it is, additionally set the current active ruleset to deprecated
-      if(ruleset?.rulesetStatus?.value == 'active'){
-        String activeRulesetId = serialRulesetService.findActive(ruleset?.owner?.id)
-        if(activeRulesetId){
-          serialRulesetService.updateRulesetStatus(activeRulesetId, 'deprecated')
-        }
-      }
+      activeRulesetCheck(ruleset)
+
       ruleset.save(failOnError: true)
       if(ruleset.hasErrors()) {
         transactionStatus.setRollbackOnly()
@@ -112,12 +117,8 @@ class SerialRulesetController extends OkapiTenantAwareController<SerialRuleset> 
       // New ruleset
       SerialRuleset ruleset = new SerialRuleset(data)
       //Check to see if new ruleset is active, if it is, additionally set the current active ruleset to deprecated
-      if(ruleset?.rulesetStatus?.value == 'active'){
-        String activeRulesetId = serialRulesetService.findActive(ruleset?.owner?.id)
-        if(activeRulesetId){
-          serialRulesetService.updateRulesetStatus(activeRulesetId, 'deprecated')
-        }
-      }
+      activeRulesetCheck(ruleset)
+
       ruleset.save(failOnError: true)
       if(ruleset.hasErrors()) {
         transactionStatus.setRollbackOnly()
@@ -134,12 +135,8 @@ class SerialRulesetController extends OkapiTenantAwareController<SerialRuleset> 
     SerialRuleset.withTransaction {
       def data = getObjectToBind()
       SerialRuleset ruleset = new SerialRuleset(data)
-      if(ruleset?.rulesetStatus?.value == 'active'){
-        String activeRulesetId = serialRulesetService.findActive(ruleset?.owner?.id)
-        if(activeRulesetId){
-          serialRulesetService.updateRulesetStatus(activeRulesetId, 'deprecated')
-        }
-      }
+      activeRulesetCheck(ruleset)
+
       ruleset.save(failOnError: true)
       if(ruleset.hasErrors()) {
         transactionStatus.setRollbackOnly()

--- a/service/grails-app/controllers/org/olf/SerialRulesetController.groovy
+++ b/service/grails-app/controllers/org/olf/SerialRulesetController.groovy
@@ -13,6 +13,8 @@ import grails.converters.*
 import grails.gorm.multitenancy.CurrentTenant
 import grails.gorm.transactions.Transactional
 
+import static org.springframework.http.HttpStatus.*
+
 import groovy.util.logging.Slf4j
 
 import java.util.regex.Pattern
@@ -42,7 +44,7 @@ class SerialRulesetController extends OkapiTenantAwareController<SerialRuleset> 
   }
 
   def activateRuleset() {
-    String serialRulesetId = params.get("serialRulesetId") 
+    String serialRulesetId = params.get("serialRulesetId")
     SerialRuleset ruleset = SerialRuleset.findById(serialRulesetId)
 
     String activeRulesetId = serialRulesetService.findActive(ruleset?.owner?.id)
@@ -54,10 +56,29 @@ class SerialRulesetController extends OkapiTenantAwareController<SerialRuleset> 
     respond result
   }
 
+  @Transactional
   def replaceAndDelete() {
     SerialRuleset.withTransaction {
       def data = getObjectToBind()
+      // Existing ruleset
+      String existingRulesetId = params.get("serialRulesetId") 
+      SerialRuleset existing = queryForResource(existingRulesetId)
+      // If existing ruleset doesnt exist, return error
+      if (existing == null) {
+        transactionStatus.setRollbackOnly()
+        notFound()
+        return
+      }
+      // Check to see if the existing ruleset has any predicted piece sets associated with it
+      Integer pieceSetCount = serialRulesetService.countPieceSets(existingRulesetId)[0]
+      if(pieceSetCount > 0){
+        transactionStatus.setRollbackOnly()
+        render status: METHOD_NOT_ALLOWED, text: "Cannot delete a serial ruleset which has been used to generate a predicted piece set"
+        return
+      }
+      // New ruleset
       SerialRuleset ruleset = new SerialRuleset(data)
+      //Check to see if new ruleset is active, if it is, additionally set the current active ruleset to deprecated
       if(ruleset?.rulesetStatus?.value == 'active'){
         String activeRulesetId = serialRulesetService.findActive(ruleset?.owner?.id)
         if(activeRulesetId){
@@ -69,14 +90,28 @@ class SerialRulesetController extends OkapiTenantAwareController<SerialRuleset> 
         transactionStatus.setRollbackOnly()
         respond ruleset.errors
       }
+      // Finally delete the predicted piece set if we get this far and respond.
+      deleteResource existing
       respond ruleset
     }
   }
 
+  @Transactional
   def replaceAndDeprecate() {
     SerialRuleset.withTransaction {
       def data = getObjectToBind()
+      // Existing ruleset
+      String existingRulesetId = params.get("serialRulesetId") 
+      SerialRuleset existing = queryForResource(existingRulesetId)
+      // If existing ruleset doesnt exist, return error
+      if (existing == null) {
+        transactionStatus.setRollbackOnly()
+        notFound()
+        return
+      }
+      // New ruleset
       SerialRuleset ruleset = new SerialRuleset(data)
+      //Check to see if new ruleset is active, if it is, additionally set the current active ruleset to deprecated
       if(ruleset?.rulesetStatus?.value == 'active'){
         String activeRulesetId = serialRulesetService.findActive(ruleset?.owner?.id)
         if(activeRulesetId){
@@ -88,6 +123,8 @@ class SerialRulesetController extends OkapiTenantAwareController<SerialRuleset> 
         transactionStatus.setRollbackOnly()
         respond ruleset.errors
       }
+      // Finally deprecate existing ruleset
+      serialRulesetService.updateRulesetStatus(existingRulesetId, 'deprecated')
       respond ruleset
     }
   }

--- a/service/grails-app/controllers/org/olf/SerialRulesetController.groovy
+++ b/service/grails-app/controllers/org/olf/SerialRulesetController.groovy
@@ -3,12 +3,15 @@ package org.olf
 import org.olf.SerialRuleset
 import org.olf.SerialRulesetService
 
+import org.olf.recurrence.Recurrence
+
 import com.k_int.okapi.OkapiTenantAwareController
 import com.k_int.web.toolkit.refdata.RefdataValue
 
 import grails.rest.*
 import grails.converters.*
 import grails.gorm.multitenancy.CurrentTenant
+import grails.gorm.transactions.Transactional
 
 import groovy.util.logging.Slf4j
 
@@ -51,18 +54,50 @@ class SerialRulesetController extends OkapiTenantAwareController<SerialRuleset> 
     respond result
   }
 
+  def replaceAndDelete() {
 
+  }
 
-  def save() {
-    def data = getObjectToBind()
-    SerialRuleset ruleset = new SerialRuleset(data)
-    if(ruleset?.rulesetStatus?.value == 'active'){
-      String activeRulesetId = serialRulesetService.findActive(ruleset?.owner?.id)
-      if(activeRulesetId){
-        serialRulesetService.updateRulesetStatus(activeRulesetId, 'deprecated')
+  def replaceAndDeprecate() {
+    // TODO THis will be our ruleset 'editing' endpoint
+    // Only allow editing if the ruleset is in draft
+    // Ensure that the ruleset has no associated predicted piece sets
+    // Additionally ensure that if the 'replace' action fails, do NOT delete the old ruleset
+    SerialRuleset.withTransaction {
+      def data = getObjectToBind()
+      SerialRuleset ruleset = new SerialRuleset(data)
+      if(ruleset?.rulesetStatus?.value == 'active'){
+        String activeRulesetId = serialRulesetService.findActive(ruleset?.owner?.id)
+        if(activeRulesetId){
+          serialRulesetService.updateRulesetStatus(activeRulesetId, 'deprecated')
+        }
       }
+      ruleset.save(failOnError: true)
+      if(ruleset.hasErrors()) {
+        transactionStatus.setRollbackOnly()
+        respond ruleset.errors
+      }
+      respond ruleset
     }
-    ruleset.save(flush: true, failOnError: true)
-    respond ruleset
+  }
+
+  @Transactional
+  def save() {
+    SerialRuleset.withTransaction {
+      def data = getObjectToBind()
+      SerialRuleset ruleset = new SerialRuleset(data)
+      if(ruleset?.rulesetStatus?.value == 'active'){
+        String activeRulesetId = serialRulesetService.findActive(ruleset?.owner?.id)
+        if(activeRulesetId){
+          serialRulesetService.updateRulesetStatus(activeRulesetId, 'deprecated')
+        }
+      }
+      ruleset.save(failOnError: true)
+      if(ruleset.hasErrors()) {
+        transactionStatus.setRollbackOnly()
+        respond ruleset.errors
+      }
+      respond ruleset
+    }
   }
 }

--- a/service/grails-app/controllers/org/olf/UrlMappings.groovy
+++ b/service/grails-app/controllers/org/olf/UrlMappings.groovy
@@ -20,6 +20,8 @@ class UrlMappings {
       '/active' (controller: 'serialRuleset', action: 'activateRuleset', method: 'POST')
       '/deprecated' (controller: 'serialRuleset', action: 'deprecateRuleset', method: 'POST')
       '/draft' (controller: 'serialRuleset', action: 'draftRuleset', method: 'POST')
+
+      '/replace' (controller: 'serialRuleset', action: 'replace', method: 'POST')
     }
 
     "/serials-management/predictedPieces" (resources: 'predictedPieceSet') {

--- a/service/grails-app/controllers/org/olf/UrlMappings.groovy
+++ b/service/grails-app/controllers/org/olf/UrlMappings.groovy
@@ -21,7 +21,8 @@ class UrlMappings {
       '/deprecated' (controller: 'serialRuleset', action: 'deprecateRuleset', method: 'POST')
       '/draft' (controller: 'serialRuleset', action: 'draftRuleset', method: 'POST')
 
-      '/replace' (controller: 'serialRuleset', action: 'replace', method: 'POST')
+      '/replaceAndDeprecate' (controller: 'serialRuleset', action: 'replaceAndDeprecate', method: 'POST')
+      '/replaceAndDelete' (controller: 'serialRuleset', action: 'replaceAndDelete', method: 'POST')
     }
 
     "/serials-management/predictedPieces" (resources: 'predictedPieceSet') {

--- a/service/grails-app/controllers/org/olf/UrlMappings.groovy
+++ b/service/grails-app/controllers/org/olf/UrlMappings.groovy
@@ -16,7 +16,7 @@ class UrlMappings {
     "/serials-management/serials" (resources: 'serial')
 
     "/serials-management/rulesets" (resources: 'serialRuleset'){
-      
+
       '/active' (controller: 'serialRuleset', action: 'activateRuleset', method: 'POST')
       '/deprecated' (controller: 'serialRuleset', action: 'deprecateRuleset', method: 'POST')
       '/draft' (controller: 'serialRuleset', action: 'draftRuleset', method: 'POST')

--- a/service/grails-app/domain/org/olf/recurrence/Recurrence.groovy
+++ b/service/grails-app/domain/org/olf/recurrence/Recurrence.groovy
@@ -18,7 +18,7 @@ public class Recurrence implements MultiTenant<Recurrence> {
 
   Integer issues // 7
   Integer period // 3 / Frequency
-
+  
   Set<RecurrenceRule> rules// Validate to have exactly #issues of these
 
   static belongsTo = [

--- a/service/grails-app/services/org/olf/HousekeepingService.groovy
+++ b/service/grails-app/services/org/olf/HousekeepingService.groovy
@@ -82,7 +82,7 @@ class HousekeepingService {
             level.rawValue = level.value as Integer
             level.valueFormat = RefdataValue.lookupOrCreate('EnumerationNumericLevelTMRF.Format', 'Number')
           }
-      
+          // TODO Check this should actually be a flush
           level.save(flush:true, failOnError:true)
         }
       }

--- a/service/grails-app/services/org/olf/SerialRulesetService.groovy
+++ b/service/grails-app/services/org/olf/SerialRulesetService.groovy
@@ -21,7 +21,7 @@ class SerialRulesetService {
     SerialRuleset ruleset = SerialRuleset.findById(rulesetId)
 
     ruleset.rulesetStatus = updatedStatus
-    ruleset.save(flush: true, failOnError: true)
+    ruleset.save(failOnError: true)
 
     return ruleset
   }

--- a/service/grails-app/services/org/olf/SerialRulesetService.groovy
+++ b/service/grails-app/services/org/olf/SerialRulesetService.groovy
@@ -10,6 +10,12 @@ import com.k_int.web.toolkit.refdata.RefdataValue
 @Transactional
 class SerialRulesetService {
 
+  List<Integer> countPieceSets(String rulesetId) {
+    return PredictedPieceSet.executeQuery("""
+      SELECT COUNT(pps.id) from PredictedPieceSet as pps WHERE pps.ruleset.id = :rulesetId
+    """.toString(), [rulesetId: rulesetId,])
+  }
+
   String findActive(String serialId) {
     return SerialRuleset.executeQuery("""
       SELECT id from SerialRuleset WHERE owner.id = :serialId AND rulesetStatus.value = :active

--- a/service/src/main/okapi/ModuleDescriptor-template.json
+++ b/service/src/main/okapi/ModuleDescriptor-template.json
@@ -72,6 +72,11 @@
           "permissionsRequired": [ "serials-management.rulesets.item.post" ]
         },
         {
+          "methods": ["PUT"],
+          "pathPattern": "/serials-management/rulesets/{id}",
+          "permissionsRequired": [ "serials-management.rulesets.item.put" ]
+        },
+        {
           "methods": ["DELETE"],
           "pathPattern": "/serials-management/rulesets/{id}",
           "permissionsRequired": [ "serials-management.rulesets.item.delete" ]

--- a/service/src/main/okapi/ModuleDescriptor-template.json
+++ b/service/src/main/okapi/ModuleDescriptor-template.json
@@ -72,11 +72,6 @@
           "permissionsRequired": [ "serials-management.rulesets.item.post" ]
         },
         {
-          "methods": ["PUT"],
-          "pathPattern": "/serials-management/rulesets/{id}",
-          "permissionsRequired": [ "serials-management.rulesets.item.put" ]
-        },
-        {
           "methods": ["DELETE"],
           "pathPattern": "/serials-management/rulesets/{id}",
           "permissionsRequired": [ "serials-management.rulesets.item.delete" ]
@@ -94,6 +89,11 @@
         {
           "methods": ["POST"],
           "pathPattern": "/serials-management/rulesets/{id}/draft",
+          "permissionsRequired": [ "serials-management.rulesets.item.put" ]
+        },
+        {
+          "methods": ["POST"],
+          "pathPattern": "/serials-management/rulesets/{id}/replace",
           "permissionsRequired": [ "serials-management.rulesets.item.put" ]
         },
         {

--- a/service/src/main/okapi/ModuleDescriptor-template.json
+++ b/service/src/main/okapi/ModuleDescriptor-template.json
@@ -122,6 +122,11 @@
           "permissionsRequired": [ "serials-management.predictedPieceSets.item.post" ]
         },
         {
+          "methods": ["DELETE"],
+          "pathPattern": "/serials-management/predictedPieces/{id}",
+          "permissionsRequired": [ "serials-management.predictedPieceSets.item.delete" ]
+        },
+        {
           "methods": ["GET"],
           "pathPattern": "/serials-management/locales",
           "permissionsRequired": [ "serials-management.locales.collection.get" ]

--- a/service/src/main/okapi/ModuleDescriptor-template.json
+++ b/service/src/main/okapi/ModuleDescriptor-template.json
@@ -176,14 +176,14 @@
             "POST"
           ],
           "pathPattern": "/serials-management/rulesets/{id}/replaceAndDeprecate",
-          "permissionsRequired": [ "serials-management.rulesets.item.put" ]
+          "permissionsRequired": [ "serials-management.rulesets.replace-deprecate.execute" ]
         },
         {
           "methods": [
             "POST"
           ],
           "pathPattern": "/serials-management/rulesets/{id}/replaceAndDelete",
-          "permissionsRequired": [ "serials-management.rulesets.item.put" ]
+          "permissionsRequired": [ "serials-management.rulesets.replace-delete.execute" ]
         },
         {
           "methods": [
@@ -491,13 +491,25 @@
       ]
     },
     {
+      "permissionName": "serials-management.rulesets.replace-delete.execute",
+      "displayName": "Replace and delete a ruleset",
+      "description": "Permit the deletion and replacement of a ruleset"
+    },
+    {
+      "permissionName": "serials-management.rulesets.replace-deprecate.execute",
+      "displayName": "Replace and deprecate a ruleset",
+      "description": "Permit the deprecation and replacement of a ruleset"
+    },
+    {
       "permissionName": "serials-management.rulesets.edit",
       "subPermissions": [
         "serials-management.rulesets.view",
         "serials-management.rulesets.item.post",
         "serials-management.rulesets.set-active.execute",
         "serials-management.rulesets.set-deprecated.execute",
-        "serials-management.rulesets.set-draft.execute"
+        "serials-management.rulesets.set-draft.execute",
+        "serials-management.rulesets.replace-delete.execute",
+        "serials-management.rulesets.replace-deprecate.execute"
       ]
     },
     {


### PR DESCRIPTION
Purpose:
To support an edit option for publication patterns that have not yet been used to generate predicted pieces. If there are any predicted piece sets linked to a publication pattern it will not be possible to edit the pattern (although an active pattern can be deprecated by making a new active pattern as currently)
