### PR TITLE
MODSER-56: Internal omission/combination pieces not expanding fields

### DIFF
--- a/service/grails-app/views/internalCombinationPiece/_internalCombinationPiece.gson
+++ b/service/grails-app/views/internalCombinationPiece/_internalCombinationPiece.gson
@@ -8,4 +8,6 @@ def should_expand = [
 ]
 
 @Field InternalCombinationPiece internalCombinationPiece
-json g.render(internalCombinationPiece, [excludes: ['owner'], expand: should_expand])
+json g.render(internalCombinationPiece, [excludes: ['owner'], expand: should_expand]){
+  'class' internalCombinationPiece.class.name
+}

--- a/service/grails-app/views/internalOmissionPiece/_internalOmissionPiece.gson
+++ b/service/grails-app/views/internalOmissionPiece/_internalOmissionPiece.gson
@@ -7,4 +7,6 @@ def should_expand = [
 ]
 
 @Field InternalOmissionPiece internalOmissionPiece
-json g.render(internalOmissionPiece, [expand: should_expand])
+json g.render(internalOmissionPiece, [excludes: ['owner'], expand: should_expand]){
+  'class' internalOmissionPiece.class.name
+}

--- a/service/grails-app/views/internalPiece/_internalPiece.gson
+++ b/service/grails-app/views/internalPiece/_internalPiece.gson
@@ -1,8 +1,23 @@
 import groovy.transform.*
 import org.olf.internalPiece.InternalPiece
 import groovy.transform.Field
+import org.grails.orm.hibernate.cfg.GrailsHibernateUtil
 
 def should_expand = ['receivingPieces', 'templateMetadata']
 
 @Field InternalPiece internalPiece
-json g.render(internalPiece, [expand: should_expand])
+internalPiece = GrailsHibernateUtil.unwrapIfProxy(internalPiece) as InternalPiece
+
+switch(internalPiece.class.name){
+  case 'org.olf.internalPiece.InternalOmissionPiece':
+    json g.render (template: '/internalOmissionPiece/internalOmissionPiece', model: [internalOmissionPiece: binding.variables.internalPiece])
+    break;
+  case 'org.olf.internalPiece.InternalRecurrencePiece':
+    json g.render (template: '/internalRecurrencePiece/internalRecurrencePiece', model: [internalRecurrencePiece: binding.variables.internalPiece])
+    break;
+  case 'org.olf.internalPiece.InternalCombinationPiece':
+    json g.render (template: '/internalCombinationPiece/internalCombinationPiece', model: [internalCombinationPiece: binding.variables.internalPiece])
+    break;
+  default:
+    throw new RuntimeException("Unexpected internalPiece class ${internalPiece.class.name}")
+}

--- a/service/grails-app/views/internalRecurrencePiece/_internalRecurrencePiece.gson
+++ b/service/grails-app/views/internalRecurrencePiece/_internalRecurrencePiece.gson
@@ -7,4 +7,6 @@ def should_expand = [
 ]
 
 @Field InternalRecurrencePiece internalRecurrencePiece
-json g.render(internalRecurrencePiece, [excludes: ['owner'], expand: should_expand])
+json g.render(internalRecurrencePiece, [excludes: ['owner'], expand: should_expand]){
+  'class' internalRecurrencePiece.class.name
+}


### PR DESCRIPTION
Previously, internal recurrence/omission/combination pieces were not expanding the fields contained within their models, in order to fix this, the internal piece view file has been changes to dynamically select the correct internal piece view file based on the class, additionally a class field has been added to allow for easier identification of the piece class on the front end