### PR TITLE
MODSER-50: Update module license, guidance and dependencies

### DIFF
--- a/GUIDANCE.md
+++ b/GUIDANCE.md
@@ -1,0 +1,11 @@
+This file is an addendum to LICENSE.md.
+
+K-Int is a firm believer in the open source movement, but we also feel that it can be abused.
+
+This file sets out our EXPECTATIONS and what we HOPE for from users of this code, especially users who take this code and use it as a part of a pay-for SAAS solution.
+
+The investment of time in this code, and the cost of maintaining and patching it over time is not trivial. Therefore, we EXPECT that if you are using this code as a part of a hosted solution, you will find some way to siphon a part of your fees off to this module. Most often, this library will be a part of a FOLIO module, and a similar file will accompany each FOLIO license setting out what we think is a fair donation from each "tenant" who uses this code.
+
+If you have created a new module based on this library, please get in touch to discuss ways you can support our work.
+
+Whilst we cannot prevent anyone from using the code as supplied under the APL - we would ask that SAAS companies and self hosters take notice of this file and behave appropriately, in order to secure the future of open source as a viable way to address the software problem.

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+   The license must be read in conjunction with GUIDANCE.md
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -175,18 +177,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2024 Knowledge Integration Ltd
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -129,8 +129,8 @@ dependencies {
   //testImplementation("io.micronaut:micronaut-http-client")
 
 	/*  ---- Manually installed dependencies ---- */
-	implementation 'com.k_int.grails:web-toolkit-ce:9.0.0'
-	implementation('com.k_int.okapi:grails-okapi:7.1.0') {
+	implementation 'com.k_int.grails:web-toolkit-ce:10.0.1'
+	implementation('com.k_int.okapi:grails-okapi:7.3.0') {
     exclude group: 'com.vaadin.external.google', module: 'android-json'
   }
 	


### PR DESCRIPTION
Bumped dependency for web-toolkit to 10.0.1 and grails-okpai to 7.3.0
updated license.md and added guidance.md file
