### PR TITLE
build: okapiInterfaceVersion

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## 1.1.0 In progress
+  * Separate out okapi interface version from module version
 
 ## 1.0.3 2024-04-26
   * MODSER-35 Endpoints should be protected by fine-grained permissions

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -288,6 +288,8 @@ project.gradle.projectsEvaluated {
 		// Get a System property
 		properties.setProperty('build.java.version', System.getProperty('java.version'))
 
+		properties.setProperty('okapiInterfaceVersion', "$okapiInterfaceVersion")
+
 		// Write the properties back to the file
 		grailsBuildInfoFile.withOutputStream {
 			properties.store(it,null)

--- a/service/gradle.properties
+++ b/service/gradle.properties
@@ -12,5 +12,6 @@ gradleWrapperVersion=5.4
 # Application
 appName=mod-serials-management
 appVersion=1.1.0-SNAPSHOT
+okapiInterfaceVersion=1.1
 dockerTagSuffix=
 dockerRepo=folioci

--- a/service/src/main/okapi/ModuleDescriptor-template.json
+++ b/service/src/main/okapi/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "serials-management",
-      "version": "${info.app.minorVersion}",
+      "version": "${okapiInterfaceVersion}",
       "handlers": [
         {
           "methods": [


### PR DESCRIPTION
Separate out okapiInterfaceVersion from module version so future module major bumps that don't change interface shape can be handled separately