### PR TITLE
MODSER-60: Receiving piece count not displaying in predicted piece set

### DIFF
--- a/service/grails-app/views/internalCombinationPiece/_internalCombinationPiece.gson
+++ b/service/grails-app/views/internalCombinationPiece/_internalCombinationPiece.gson
@@ -5,6 +5,7 @@ import groovy.transform.Field
 def should_expand = [
   'recurrencePieces',
   'combinationOrigins',
+  'receivingPieces'
 ]
 
 @Field InternalCombinationPiece internalCombinationPiece

--- a/service/grails-app/views/internalOmissionPiece/_internalOmissionPiece.gson
+++ b/service/grails-app/views/internalOmissionPiece/_internalOmissionPiece.gson
@@ -2,8 +2,10 @@ import groovy.transform.*
 import org.olf.internalPiece.InternalOmissionPiece
 import groovy.transform.Field
 
+// We may wish to remove receivingPieces from this in the future
 def should_expand = [
   'omissionOrigins',
+  'receivingPieces'
 ]
 
 @Field InternalOmissionPiece internalOmissionPiece

--- a/service/grails-app/views/internalPiece/_internalPiece.gson
+++ b/service/grails-app/views/internalPiece/_internalPiece.gson
@@ -3,8 +3,6 @@ import org.olf.internalPiece.InternalPiece
 import groovy.transform.Field
 import org.grails.orm.hibernate.cfg.GrailsHibernateUtil
 
-def should_expand = ['receivingPieces', 'templateMetadata']
-
 @Field InternalPiece internalPiece
 internalPiece = GrailsHibernateUtil.unwrapIfProxy(internalPiece) as InternalPiece
 

--- a/service/grails-app/views/internalRecurrencePiece/_internalRecurrencePiece.gson
+++ b/service/grails-app/views/internalRecurrencePiece/_internalRecurrencePiece.gson
@@ -4,6 +4,7 @@ import groovy.transform.Field
 
 def should_expand = [
   'recurrenceRule',
+  'receivingPieces'
 ]
 
 @Field InternalRecurrencePiece internalRecurrencePiece


### PR DESCRIPTION
Fixed a bug in which receiving pieces were not being expanded in the internal piece model

[MODSER-60](https://folio-org.atlassian.net/browse/MODSER-60)