### PR TITLE
fix: Multiple levels of continuous enumeration in a publication pattern result in incorrect numbering

### DIFF
--- a/service/grails-app/controllers/org/olf/PredictedPieceSetController.groovy
+++ b/service/grails-app/controllers/org/olf/PredictedPieceSetController.groovy
@@ -9,6 +9,7 @@ import org.olf.PredictedPieceSet
 import org.olf.internalPiece.templateMetadata.TemplateMetadata
 import org.olf.internalPiece.templateMetadata.UserConfiguredTemplateMetadata
 import org.olf.internalPiece.InternalPiece
+import org.olf.templating.LabelTemplateBindings
 
 import com.k_int.okapi.OkapiTenantAwareController
 
@@ -47,7 +48,7 @@ class PredictedPieceSetController extends OkapiTenantAwareController<PredictedPi
 
     ArrayList<InternalPiece> ips = pieceGenerationService.createPiecesTransient(ruleset, LocalDate.parse(data.startDate))
 
-    TemplateMetadata initialPieceRecurrenceMetadata = pieceLabellingService.generateTemplateMetadataForPiece(ips?.get(0), ips, ruleset?.templateConfig, startingValues)
+    TemplateMetadata initialPieceRecurrenceMetadata = pieceLabellingService.generateTemplateMetadataForPiece(ips?.get(0), ips, ruleset?.templateConfig, startingValues, null)
 
     // Check for omission rules within the ruleset
     // Since we presently only handle omissions OR combinations, only one should ever been applied to the internal pieces
@@ -56,10 +57,11 @@ class PredictedPieceSetController extends OkapiTenantAwareController<PredictedPi
     } else if (!!ruleset?.combination) {
       pieceGenerationService.applyCombinationRules(ips, ruleset)
     }
-    pieceLabellingService.setLabelsForInternalPieces(ips, ruleset?.templateConfig, startingValues)
+    // TODO This should be seperated out into one method setting labels for pieces and another that grabs last piece template bindings
+    LabelTemplateBindings lastPieceLabelTemplateBindings = pieceLabellingService.setLabelsForInternalPieces(ips, ruleset?.templateConfig, startingValues)
 
     InternalPiece nextPiece = pieceGenerationService.generateNextPiece(ips.get(ips.size()-1), ruleset)
-    TemplateMetadata continuationPieceRecurrenceMetadata = pieceLabellingService.generateTemplateMetadataForPiece(nextPiece, ips, ruleset?.templateConfig, startingValues)
+    TemplateMetadata continuationPieceRecurrenceMetadata = pieceLabellingService.generateTemplateMetadataForPiece(nextPiece, ips, ruleset?.templateConfig, startingValues, lastPieceLabelTemplateBindings?.enumerationArray)
 
     PredictedPieceSet pps = new PredictedPieceSet([
       ruleset: ruleset,

--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationNumericTMRF.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationNumericTMRF.groovy
@@ -55,15 +55,13 @@ public class EnumerationNumericTMRF extends TemplateMetadataRuleFormat implement
     for(int i=enltmrfArray?.size()-1; i>=0; i--){
 
       // Set value to previous pieces corresponding value
-      Integer value = svArray?.getAt(i)?.rawValue ?: svArray?.getAt(i)?.value
+      Integer value = (svArray?.getAt(i)?.rawValue ?: svArray?.getAt(i)?.value) as Integer
       // Only calculate if we're past the first piece, otherwise use starting values
       if(index != 0){
         //If previous level has set flag to  true, increment
         //Always incremement on lowest level then set to false so higher levels should only ever increment with permission from lower levels
         if(shouldIncrement == true){
-          if (value % enltmrfArray[i]?.units == 0) {
-            shouldIncrement = true
-          }else{
+          if (value % enltmrfArray[i]?.units != 0) {
             shouldIncrement = false
           }
           value ++

--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationNumericTMRF.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationNumericTMRF.groovy
@@ -47,7 +47,7 @@ public class EnumerationNumericTMRF extends TemplateMetadataRuleFormat implement
     // Array of EnumerationNumericLevels sorted by index
     ArrayList<EnumerationNumericLevelTMRF> enltmrfArray = rule?.ruleType?.ruleFormat?.levels?.sort { it?.index }
     // Array of starting values sorted by index
-    ArrayList<EnumerationLevelUCTMT> levellevelStartingValueArray = startingValues?.levels?.sort { it?.index }
+    ArrayList<EnumerationLevelUCTMT> levelStartingValueArray = startingValues?.levels?.sort { it?.index }
     ArrayList<EnumerationLevelUCTMT> result = []
 
     // Will always be true for the lowest level of enumeration, decides whether subsequent levels should be incremented

--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationNumericTMRF.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationNumericTMRF.groovy
@@ -47,15 +47,15 @@ public class EnumerationNumericTMRF extends TemplateMetadataRuleFormat implement
     // Array of EnumerationNumericLevels sorted by index
     ArrayList<EnumerationNumericLevelTMRF> enltmrfArray = rule?.ruleType?.ruleFormat?.levels?.sort { it?.index }
     // Array of starting values sorted by index
-    ArrayList<EnumerationLevelUCTMT> svArray = startingValues?.levels?.sort { it?.index }
+    ArrayList<EnumerationLevelUCTMT> levellevelStartingValueArray = startingValues?.levels?.sort { it?.index }
     ArrayList<EnumerationLevelUCTMT> result = []
 
+    // Will always be true for the lowest level of enumeration, decides whether subsequent levels should be incremented
     Boolean shouldIncrement = true
     // Iterate through the EnumerationNumericLevels starting at the lowest level
     for(int i=enltmrfArray?.size()-1; i>=0; i--){
-
       // Set value to previous pieces corresponding value
-      Integer value = (svArray?.getAt(i)?.rawValue ?: svArray?.getAt(i)?.value) as Integer
+      Integer value = levelStartingValueArray?.getAt(i)?.rawValue as Integer ?: 1
       // Only calculate if we're past the first piece, otherwise use starting values
       if(index != 0){
         //If previous level has set flag to  true, increment

--- a/service/grails-app/services/org/olf/PieceLabellingService.groovy
+++ b/service/grails-app/services/org/olf/PieceLabellingService.groovy
@@ -34,23 +34,40 @@ public class PieceLabellingService {
 
 
   // This needs to take in an individual piece and ooutput a String label
-  public String generateTemplatedLabelForPiece(InternalPiece piece, ArrayList<InternalPiece> internalPieces, TemplateConfig templateConfig, ArrayList<UserConfiguredTemplateMetadata> startingValues) { 
-    Template template = hte.createTemplate(templateConfig.templateString);
-    // Template template = hte.createTemplate("EA {{chronology1.year}} {{chronologyArray.0.year}} {{test}}")
-
+  // PreviousLabelTemplateBindings will b null for first piece
+  public LabelTemplateBindings generateTemplateBindingsForPiece(
+    InternalPiece piece,
+    ArrayList<InternalPiece> internalPieces,
+    TemplateConfig templateConfig,
+    ArrayList<UserConfiguredTemplateMetadata> startingValues,
+    LabelTemplateBindings previousLabelTemplateBindings
+  ){
     StandardTemplateMetadata standardTM = generateStandardMetadata(piece, internalPieces)
     // Having to enforce a sort here
     Set<TemplateMetadataRule> sortedRules = templateConfig.rules?.sort{ it.index }
     ArrayList<UserConfiguredTemplateMetadata> sortedStartingValues = startingValues?.sort{ it.index }
 
+    // Makig assumption that chronologies dont have starting values
     ArrayList<ChronologyUCTMT> chronologyArray = generateChronologyMetadata(standardTM, sortedRules)
-    ArrayList<EnumerationUCTMT> enumerationArray = generateEnumerationMetadata(standardTM, sortedRules, sortedStartingValues)
+    ArrayList<EnumerationUCTMT> enumerationArray = generateEnumerationMetadata(
+      standardTM, 
+      sortedRules, 
+      sortedStartingValues, 
+      previousLabelTemplateBindings?.enumerationArray
+    )
 
     LabelTemplateBindings ltb = new LabelTemplateBindings()
     ltb.setupChronologyArray(chronologyArray)
     ltb.setupEnumerationArray(enumerationArray)
     ltb.setupStandardTM(standardTM)
 
+    return ltb
+  }
+
+  public String generateLabelForPiece(LabelTemplateBindings ltb, String templateString){
+    Template template = hte.createTemplate(templateString);
+    // Template template = hte.createTemplate("EA {{chronology1.year}} {{chronologyArray.0.year}} {{test}}")
+    
     return template.make(ltb).with { 
       StringWriter sw = new StringWriter()
       writeTo(sw)
@@ -60,12 +77,16 @@ public class PieceLabellingService {
 
   public void setLabelsForInternalPieces(ArrayList<InternalPiece> internalPieces, TemplateConfig templateConfig, ArrayList<UserConfiguredTemplateMetadata> startingValues) {
     ListIterator<InternalPiece> iterator = internalPieces?.listIterator()
+    LabelTemplateBindings previousLabelTemplateBindings = null
     while(iterator.hasNext()){
       InternalPiece currentPiece = iterator.next()
       if(currentPiece instanceof InternalRecurrencePiece || currentPiece instanceof InternalCombinationPiece){
-        String label = generateTemplatedLabelForPiece(currentPiece, internalPieces, templateConfig, startingValues)
+        // String label = generateTemplatedLabelForPiece(currentPiece, internalPieces, templateConfig, startingValues)
+        LabelTemplateBindings ltb = generateTemplateBindingsForPiece(currentPiece, internalPieces, templateConfig, startingValues, previousLabelTemplateBindings)
+        String label = generateLabelForPiece(ltb, templateConfig?.templateString)
         currentPiece.label = label
         currentPiece.templateString = templateConfig?.templateString
+        previousLabelTemplateBindings = ltb
       }
     }
   }
@@ -160,18 +181,28 @@ public class PieceLabellingService {
     return chronologyTemplateMetadataArray
   }
 
-  public ArrayList<EnumerationUCTMT> generateEnumerationMetadata(StandardTemplateMetadata standardTM, Set<TemplateMetadataRule> templateMetadataRules, ArrayList<UserConfiguredTemplateMetadata> startingValues) {
+  public ArrayList<EnumerationUCTMT> generateEnumerationMetadata(
+    StandardTemplateMetadata standardTM, 
+    Set<TemplateMetadataRule> templateMetadataRules, 
+    ArrayList<UserConfiguredTemplateMetadata> startingValues,
+    ArrayList<EnumerationUCTMT> previousEnumerationArray
+  ) {
     ArrayList<EnumerationUCTMT> enumerationTemplateMetadataArray = []
     Iterator<TemplateMetadataRule> iterator = templateMetadataRules?.iterator()
+    // TODO This should get neater once enumeration/chronology are seperated
+    int enumerationIndex = 0
     while(iterator?.hasNext()){
       TemplateMetadataRule currentMetadataRule = iterator.next()
       String templateMetadataType = RGX_METADATA_RULE_TYPE.matcher(currentMetadataRule?.templateMetadataRuleType?.value).replaceAll { match -> match.group(1).toUpperCase() }
       if(templateMetadataType == 'enumeration'){
         Class<? extends TemplateMetadataRuleType> tmrte = Class.forName("org.olf.templateConfig.templateMetadataRule.${templateMetadataType.capitalize()}TemplateMetadataRule")
-        EnumerationUCTMT ruleStartingValues = startingValues.getAt(currentMetadataRule?.index)?.metadataType
+        // EnumerationUCTMT ruleStartingValues = startingValues.getAt(currentMetadataRule?.index)?.metdataType
+        // previousEnumerationArray might be null
+        EnumerationUCTMT ruleStartingValues = previousEnumerationArray ? previousEnumerationArray?.getAt(enumerationIndex) : startingValues.getAt(currentMetadataRule?.index)?.metadataType
         EnumerationUCTMT enumerationUCTMT = tmrte.handleType(currentMetadataRule, standardTM.date, standardTM.index, ruleStartingValues)
 
         enumerationTemplateMetadataArray << enumerationUCTMT
+        enumerationIndex++
       }
     }
     return enumerationTemplateMetadataArray


### PR DESCRIPTION
Fixed an issue in which multiple levels of continuous enumeration caused the starting values to not be used correctly when calculating the enumaration levels, a refactor to how we calculate enumeration numeric levels has been implemented and tests will be put in place to clarify this