### PR TITLE
MODSER-67: Support option to generate multiple years/cycles when generating predicted pieces

### DIFF
--- a/service/grails-app/controllers/org/olf/PredictedPieceSetController.groovy
+++ b/service/grails-app/controllers/org/olf/PredictedPieceSetController.groovy
@@ -46,7 +46,7 @@ class PredictedPieceSetController extends OkapiTenantAwareController<PredictedPi
 
     ArrayList<UserConfiguredTemplateMetadata> startingValues = new ArrayList<UserConfiguredTemplateMetadata>(startingValuesJson)
 
-    Integer numberOfCycles = data?.numberOfCycles ?: 1
+    Integer numberOfCycles = data?.numberOfCycles as Integer ?: 1
 
     ArrayList<InternalPiece> ips = pieceGenerationService.createPiecesTransient(ruleset, LocalDate.parse(data.startDate), numberOfCycles)
 

--- a/service/grails-app/controllers/org/olf/PredictedPieceSetController.groovy
+++ b/service/grails-app/controllers/org/olf/PredictedPieceSetController.groovy
@@ -70,6 +70,7 @@ class PredictedPieceSetController extends OkapiTenantAwareController<PredictedPi
       pieces: ips,
       note: data?.note,
       startDate: data?.startDate,
+      numberOfCycles: numberOfCycles,
       initialPieceRecurrenceMetadata: initialPieceRecurrenceMetadata,
       continuationPieceRecurrenceMetadata: continuationPieceRecurrenceMetadata
     ])

--- a/service/grails-app/controllers/org/olf/PredictedPieceSetController.groovy
+++ b/service/grails-app/controllers/org/olf/PredictedPieceSetController.groovy
@@ -46,7 +46,9 @@ class PredictedPieceSetController extends OkapiTenantAwareController<PredictedPi
 
     ArrayList<UserConfiguredTemplateMetadata> startingValues = new ArrayList<UserConfiguredTemplateMetadata>(startingValuesJson)
 
-    ArrayList<InternalPiece> ips = pieceGenerationService.createPiecesTransient(ruleset, LocalDate.parse(data.startDate))
+    Integer numberOfCycles = data?.numberOfCycles ?: 1
+
+    ArrayList<InternalPiece> ips = pieceGenerationService.createPiecesTransient(ruleset, LocalDate.parse(data.startDate), numberOfCycles)
 
     TemplateMetadata initialPieceRecurrenceMetadata = pieceLabellingService.generateTemplateMetadataForPiece(ips?.get(0), ips, ruleset?.templateConfig, startingValues, null)
 

--- a/service/grails-app/domain/org/olf/PredictedPieceSet.groovy
+++ b/service/grails-app/domain/org/olf/PredictedPieceSet.groovy
@@ -26,6 +26,7 @@ class PredictedPieceSet implements MultiTenant<PredictedPieceSet> {
   Date dateCreated
 
   LocalDate startDate
+  Integer numberOfCycles
 
   SerialRuleset ruleset
 
@@ -54,6 +55,7 @@ class PredictedPieceSet implements MultiTenant<PredictedPieceSet> {
     dateCreated column: 'pps_date_created'
     version column: 'pps_version'
     startDate column: 'pps_start_date'
+    numberOfCycles column: 'pps_number_of_cycles'
     note column: 'pps_note'
 
     pieces cascade: 'all-delete-orphan'
@@ -62,8 +64,9 @@ class PredictedPieceSet implements MultiTenant<PredictedPieceSet> {
   static constraints = {
     lastUpdated nullable: true
     dateCreated nullable: true
-    note nullable: true
     startDate nullable: false
+    numberOfCycles nullable: true
+    note nullable: true
     pieces nullable: false
     ruleset nullable: false
   }

--- a/service/grails-app/migrations/module-tenant-changelog.groovy
+++ b/service/grails-app/migrations/module-tenant-changelog.groovy
@@ -2,4 +2,5 @@ databaseChangeLog = {
   include file: 'initial-customisations.groovy'
   include file: 'create-mod-serials-management.groovy'
   include file: 'update-mod-serials-management-1-1.groovy'
+  include file: 'update-mod-serials-management-1-2.groovy'
 }

--- a/service/grails-app/migrations/update-mod-serials-management-1-2.groovy
+++ b/service/grails-app/migrations/update-mod-serials-management-1-2.groovy
@@ -1,0 +1,7 @@
+databaseChangeLog = {
+  changeSet(author: "Jack-Golding (manual)", id: "20241216-1339-001") {
+    addColumn(tableName: "predicted_piece_set") {
+      column(name: "pps_number_of_cycles", type: "INTEGER") { constraints(nullable: "true") }
+    }
+  }
+}

--- a/service/grails-app/services/org/olf/PieceGenerationService.groovy
+++ b/service/grails-app/services/org/olf/PieceGenerationService.groovy
@@ -39,7 +39,7 @@ public class PieceGenerationService {
   ]
 
   // This takes in a SerialRuleset and generates pieces without saving any domain objects
-  public createPiecesTransient (SerialRuleset ruleset, LocalDate startDate) {
+  public createPiecesTransient (SerialRuleset ruleset, LocalDate startDate, Integer numberOfCycles) {
     ArrayList<InternalPiece> internalPieces = []
     Map<String, Integer> timeUnitValues = [
       day: 1,
@@ -50,7 +50,7 @@ public class PieceGenerationService {
 
     // Calculate minimum whole number of years
     // Time unit * period / 365 - rounded up to next whole number
-    Integer minNumberOfYears = Math.ceil(timeUnitValues.get(ruleset?.recurrence?.timeUnit?.value) * ruleset?.recurrence?.period / 365)
+    Integer minNumberOfYears = Math.ceil(timeUnitValues.get(ruleset?.recurrence?.timeUnit?.value) * ruleset?.recurrence?.period / 365) * numberOfCycles
 
     // Establish start and end date
     LocalDate endDate = startDate.plusYears(minNumberOfYears)


### PR DESCRIPTION
Added use of numberOfCycles to determine how many years the ruleset should be run for within the PieceGenerationService

MODSER-67