### PR TITLE
MODSER-70: Update API documentation for Ramsons

### DIFF
--- a/openapi/serials-management.yaml
+++ b/openapi/serials-management.yaml
@@ -814,12 +814,14 @@ components:
         type: integer
   schemas:
     Locales:
-      type: object
-      properties:
-        label:
-          type: string
-        value:
-          type: string
+      type: array
+      items:
+        type: object
+        properties:
+          label:
+            type: string
+          value:
+            type: string
     RefData:
       type: object
       properties:


### PR DESCRIPTION
This version of the documentation is aimed at Ramsons compatibility (therefore does not include numberOfCycles which were added to Predicted piece set after Ramsons release)