### PR TITLE
refactor: Removed old starting value shape support

### DIFF
--- a/service/grails-app/controllers/org/olf/PredictedPieceSetController.groovy
+++ b/service/grails-app/controllers/org/olf/PredictedPieceSetController.groovy
@@ -38,12 +38,6 @@ class PredictedPieceSetController extends OkapiTenantAwareController<PredictedPi
   PieceLabellingService pieceLabellingService
 
   private PredictedPieceSet setupPredictedPieces(JSONObject data, JSONArray startingValuesJson, SerialRuleset ruleset) {
-    //TODO Not super happy with the implementation of this conditional, however the JSONArray .get() freaks out over null array elements vs empty
-    // This conditional is to check if the starting array contains elements and if they are of the older/newer shape
-    if(!startingValuesJson?.toString()?.contains('userConfiguredTemplateMetadataType') && startingValuesJson.size()){
-    pieceLabellingService.updateStartingValuesShape(startingValuesJson)
-    }
-
     ArrayList<UserConfiguredTemplateMetadata> startingValues = new ArrayList<UserConfiguredTemplateMetadata>(startingValuesJson)
 
     Integer numberOfCycles = data?.numberOfCycles as Integer ?: 1

--- a/service/grails-app/services/org/olf/PieceLabellingService.groovy
+++ b/service/grails-app/services/org/olf/PieceLabellingService.groovy
@@ -33,7 +33,7 @@ public class PieceLabellingService {
   .registerHelpers(StringHelpers))
 
 
-  // This needs to take in an individual piece and ooutput a String label
+  // This needs to take in an individual piece and output a String label
   // PreviousLabelTemplateBindings will b null for first piece
   public LabelTemplateBindings generateTemplateBindingsForPiece(
     InternalPiece piece,
@@ -49,7 +49,7 @@ public class PieceLabellingService {
 
     ArrayList<UserConfiguredTemplateMetadata> sortedStartingValues = startingValues?.sort{ it.index }
 
-    // Makig assumption that chronologies dont have starting values
+    // Making assumption that chronologies don't have starting values
     ArrayList<ChronologyUCTMT> chronologyArray = generateChronologyMetadata(standardTM, sortedChronologyRules)
     ArrayList<EnumerationUCTMT> enumerationArray = generateEnumerationMetadata(
       standardTM, 
@@ -270,39 +270,5 @@ public class PieceLabellingService {
         enumerationIndex++
     }
     return tm
-  }
-
-  // This functions serves as a way for the older versions of the starting values shape to be used in a newer backend version
-  public void updateStartingValuesShape(JSONArray startingValues){
-    for(int i=0;i<startingValues?.size();i++){
-    // If the element in the array is null then according to the old shape it is a chronology
-      if(startingValues.isNull(i)){
-        startingValues[i] = new JSONObject([
-          userConfiguredTemplateMetadataType: 'chronology',
-          index: i,
-          metadataType: new JSONObject()
-        ])
-      // If the element contains a "levels" key, it is assumed to be an enumeration numeric starting values
-      // Iterates through the levels contained within the list assigning an index to each
-      }else if(startingValues.get(i)?.levels?.size()){
-        JSONArray updatedLevels = []
-        JSONArray levels = startingValues.get(i)?.levels
-        for(int j=0; j<levels?.size(); j++){
-          updatedLevels << new JSONObject([value: levels[i]?.value, index: j])
-        }
-        startingValues[i] = new JSONObject([
-          userConfiguredTemplateMetadataType: 'enumeration',
-          index: i,
-          metadataType: new JSONObject([levels: updatedLevels])
-        ])
-
-      }else{
-        startingValues[i] = new JSONObject([
-          userConfiguredTemplateMetadataType: 'enumeration',
-          index: i,
-          metadataType: new JSONObject()
-        ])
-      }
-    }
   }
 }


### PR DESCRIPTION
Removed methods within piece labelling service for supporting older shapes of starting values