### PR TITLE
UISER-191/MODSER-99: Storing Textual enumeration labels with reference data IDs/Update data binding to support the use of ref data values in textual enumeration

### DIFF
--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRule/EnumerationTemplateMetadataRule.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRule/EnumerationTemplateMetadataRule.groovy
@@ -27,8 +27,8 @@ public class EnumerationTemplateMetadataRule implements MultiTenant<EnumerationT
   RefdataValue templateMetadataRuleFormat
 
   @BindUsing({ EnumerationTemplateMetadataRule obj, SimpleMapDataBindingSource source ->
-    def original = EnumerationTemplateMetadataRuleHelpers.doRuleFormatBinding(obj, source)
-    original
+    def rf = EnumerationTemplateMetadataRuleHelpers.doRuleFormatBinding(obj, source)
+    rf
   })
   EnumerationTemplateMetadataRuleFormat ruleFormat
 

--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRule/EnumerationTemplateMetadataRule.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRule/EnumerationTemplateMetadataRule.groovy
@@ -27,7 +27,8 @@ public class EnumerationTemplateMetadataRule implements MultiTenant<EnumerationT
   RefdataValue templateMetadataRuleFormat
 
   @BindUsing({ EnumerationTemplateMetadataRule obj, SimpleMapDataBindingSource source ->
-		EnumerationTemplateMetadataRuleHelpers.doRuleFormatBinding(obj, source)
+    def original = EnumerationTemplateMetadataRuleHelpers.doRuleFormatBinding(obj, source)
+    original
   })
   EnumerationTemplateMetadataRuleFormat ruleFormat
 

--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationTextualLevelTMRF.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationTextualLevelTMRF.groovy
@@ -2,28 +2,26 @@ package org.olf.templateConfig.templateMetadataRuleFormat
 
 import grails.gorm.MultiTenant
 
-import com.k_int.web.toolkit.refdata.CategoryId
-import com.k_int.web.toolkit.refdata.Defaults
 import com.k_int.web.toolkit.refdata.RefdataValue
 
-class EnumerationTextualLevelTMRF implements MultiTenant<EnumerationTextualLevelTMRF> {
+import grails.compiler.GrailsCompileStatic
+
+
+@GrailsCompileStatic
+public class EnumerationTextualLevelTMRF implements MultiTenant<EnumerationTextualLevelTMRF> {
 
   String id
-
   Integer index
-
   Integer units
-
   RefdataValue refdataValue
-
   String internalNote
-
 
   static belongsTo = [
     owner: EnumerationTextualTMRF
   ]
 
   static mapping = {
+    table 'enumeration_textual_leveltmrf'
     id column: 'etltmrf_id', generator: 'uuid2', length: 36
     owner column: 'etltmrf_owner_fk'
     version column: 'etltmrf_version'
@@ -34,7 +32,7 @@ class EnumerationTextualLevelTMRF implements MultiTenant<EnumerationTextualLevel
   }
   
   static constraints = {
-    owner(nullable:false, blank:false);
+    owner(nullable:false, blank:false)
     index nullable: false
     units nullable: false
     refdataValue nullable: false

--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationTextualLevelTMRF.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationTextualLevelTMRF.groovy
@@ -10,9 +10,10 @@ public class EnumerationTextualLevelTMRF implements MultiTenant<EnumerationTextu
   Integer index
   Integer units
 
-  String value
+  // DEPRECATED
+  String staticValue
 
-  // This needs to be passed down as refdataValue.id for reasons
+  // This needs to be passed down as refdataValue.id
   RefdataValue refdataValue
 
   String internalNote
@@ -27,7 +28,7 @@ public class EnumerationTextualLevelTMRF implements MultiTenant<EnumerationTextu
     version column: 'etltmrf_version'
     index column: 'etltmrf_index'
     units column: 'etltmrf_units'
-    value column: 'etltmrf_value'
+    staticValue column: 'etltmrf_static_value'
     refdataValue column: 'etltmrf_refdata_value_fk'
     internalNote column: 'etltmrf_internal_note'
   }
@@ -36,9 +37,17 @@ public class EnumerationTextualLevelTMRF implements MultiTenant<EnumerationTextu
     owner(nullable:false, blank:false)
     index nullable: false
     units nullable: false
-    value nullable: true
-    refdataValue nullable: false
+    staticValue nullable: true
+    refdataValue nullable: true
     internalNote nullable: true
+  }
+
+  String getValue() {
+    if (this.refdataValue?.value != null) {
+      return this?.refdataValue?.value
+    } else {
+      return this?.staticValue
+    }
   }
 }
 

--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationTextualLevelTMRF.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationTextualLevelTMRF.groovy
@@ -14,10 +14,6 @@ class EnumerationTextualLevelTMRF implements MultiTenant<EnumerationTextualLevel
 
   Integer units
 
-  // TODO shoudld be dynamically assigned refdata
-  // FIXME Should also have a more district name than just 'Value'
-//  String value
-
   RefdataValue refdataValue
 
   String internalNote
@@ -33,7 +29,6 @@ class EnumerationTextualLevelTMRF implements MultiTenant<EnumerationTextualLevel
     version column: 'etltmrf_version'
     index column: 'etltmrf_index'
     units column: 'etltmrf_units'
-//    value column: 'etltmrf_value'
     refdataValue column: 'etlmrf_refdata_value_fk'
     internalNote column: 'etltmrf_internal_note'
   }
@@ -42,7 +37,6 @@ class EnumerationTextualLevelTMRF implements MultiTenant<EnumerationTextualLevel
     owner(nullable:false, blank:false);
     index nullable: false
     units nullable: false
-//    value nullable: false
     refdataValue nullable: false
     internalNote nullable: true
   }   

--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationTextualLevelTMRF.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationTextualLevelTMRF.groovy
@@ -16,7 +16,9 @@ class EnumerationTextualLevelTMRF implements MultiTenant<EnumerationTextualLevel
 
   // TODO shoudld be dynamically assigned refdata
   // FIXME Should also have a more district name than just 'Value'
-  String value
+//  String value
+
+  RefdataValue refdataValue
 
   String internalNote
 
@@ -31,7 +33,8 @@ class EnumerationTextualLevelTMRF implements MultiTenant<EnumerationTextualLevel
     version column: 'etltmrf_version'
     index column: 'etltmrf_index'
     units column: 'etltmrf_units'
-    value column: 'etltmrf_value'
+//    value column: 'etltmrf_value'
+    refdataValue column: 'etlmrf_refdata_value_fk'
     internalNote column: 'etltmrf_internal_note'
   }
   
@@ -39,7 +42,8 @@ class EnumerationTextualLevelTMRF implements MultiTenant<EnumerationTextualLevel
     owner(nullable:false, blank:false);
     index nullable: false
     units nullable: false
-    value nullable: false
+//    value nullable: false
+    refdataValue nullable: false
     internalNote nullable: true
   }   
 }

--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationTextualLevelTMRF.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationTextualLevelTMRF.groovy
@@ -10,6 +10,8 @@ public class EnumerationTextualLevelTMRF implements MultiTenant<EnumerationTextu
   Integer index
   Integer units
 
+  String value
+
   // This needs to be passed down as refdataValue.id for reasons
   RefdataValue refdataValue
 
@@ -25,6 +27,7 @@ public class EnumerationTextualLevelTMRF implements MultiTenant<EnumerationTextu
     version column: 'etltmrf_version'
     index column: 'etltmrf_index'
     units column: 'etltmrf_units'
+    value column: 'etltmrf_value'
     refdataValue column: 'etltmrf_refdata_value_fk'
     internalNote column: 'etltmrf_internal_note'
   }
@@ -33,6 +36,7 @@ public class EnumerationTextualLevelTMRF implements MultiTenant<EnumerationTextu
     owner(nullable:false, blank:false)
     index nullable: false
     units nullable: false
+    value nullable: true
     refdataValue nullable: false
     internalNote nullable: true
   }

--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationTextualLevelTMRF.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationTextualLevelTMRF.groovy
@@ -29,7 +29,7 @@ class EnumerationTextualLevelTMRF implements MultiTenant<EnumerationTextualLevel
     version column: 'etltmrf_version'
     index column: 'etltmrf_index'
     units column: 'etltmrf_units'
-    refdataValue column: 'etlmrf_refdata_value_fk'
+    refdataValue column: 'etltmrf_refdata_value_fk'
     internalNote column: 'etltmrf_internal_note'
   }
   

--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationTextualLevelTMRF.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationTextualLevelTMRF.groovy
@@ -4,16 +4,15 @@ import grails.gorm.MultiTenant
 
 import com.k_int.web.toolkit.refdata.RefdataValue
 
-import grails.compiler.GrailsCompileStatic
-
-
-@GrailsCompileStatic
 public class EnumerationTextualLevelTMRF implements MultiTenant<EnumerationTextualLevelTMRF> {
 
   String id
   Integer index
   Integer units
+
+  // This needs to be passed down as refdataValue.id for reasons
   RefdataValue refdataValue
+
   String internalNote
 
   static belongsTo = [
@@ -21,7 +20,6 @@ public class EnumerationTextualLevelTMRF implements MultiTenant<EnumerationTextu
   ]
 
   static mapping = {
-    table 'enumeration_textual_leveltmrf'
     id column: 'etltmrf_id', generator: 'uuid2', length: 36
     owner column: 'etltmrf_owner_fk'
     version column: 'etltmrf_version'
@@ -37,6 +35,6 @@ public class EnumerationTextualLevelTMRF implements MultiTenant<EnumerationTextu
     units nullable: false
     refdataValue nullable: false
     internalNote nullable: true
-  }   
+  }
 }
 

--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationTextualTMRF.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationTextualTMRF.groovy
@@ -25,7 +25,7 @@ public class EnumerationTextualTMRF extends EnumerationTemplateMetadataRuleForma
   }
   
   static constraints = {
-    refdataCategory column: false
+    refdataCategory nullable: false
     levels nullable: false
   }
 

--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationTextualTMRF.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationTextualTMRF.groovy
@@ -38,7 +38,11 @@ public class EnumerationTextualTMRF extends EnumerationTemplateMetadataRuleForma
     for (int i = 0; i < etltmrfArray?.size(); i++) {
       index -= etltmrfArray[i]?.units;
       if (index <= 0) {
-        return etltmrfArray[i]?.refdataValue.value;
+        if (etltmrfArray[i]?.refdataValue?.value != null){
+          return etltmrfArray[i]?.refdataValue?.value
+        } else {
+          return etltmrfArray[i]?.value
+        }
       }    
     }
     return ''

--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationTextualTMRF.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationTextualTMRF.groovy
@@ -33,19 +33,16 @@ public class EnumerationTextualTMRF extends EnumerationTemplateMetadataRuleForma
     levels nullable: false
   }
 
-  private static String findResultIndex(EnumerationTemplateMetadataRule rule, int index){
+  private static String findResultIndex(EnumerationTemplateMetadataRule rule, int index) {
     ArrayList<EnumerationTextualLevelTMRF> etltmrfArray = rule?.ruleFormat?.levels?.sort { it?.index }
-    for (int i = 0; i < etltmrfArray?.size(); i++) {
-      index -= etltmrfArray[i]?.units;
-      if (index <= 0) {
-        if (etltmrfArray[i]?.refdataValue?.value != null){
-          return etltmrfArray[i]?.refdataValue?.value
-        } else {
-          return etltmrfArray[i]?.value
+    while (true) {
+      for (int i = 0; i < etltmrfArray?.size(); i++) {
+        index -= etltmrfArray[i]?.units;
+        if (index <= 0) {
+          return etltmrfArray[i]?.getValue();
         }
-      }    
+      }
     }
-    return ''
   }
 
   public static EnumerationUCTMT handleFormat (EnumerationTemplateMetadataRule rule, LocalDate date, int index, EnumerationUCTMT startingValues){

--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationTextualTMRF.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationTextualTMRF.groovy
@@ -35,14 +35,13 @@ public class EnumerationTextualTMRF extends EnumerationTemplateMetadataRuleForma
 
   private static String findResultIndex(EnumerationTemplateMetadataRule rule, int index){
     ArrayList<EnumerationTextualLevelTMRF> etltmrfArray = rule?.ruleFormat?.levels?.sort { it?.index }
-    while (true) {
-      for (int i = 0; i < etltmrfArray?.size(); i++) {
-        index -= etltmrfArray[i]?.units;
-        if (index <= 0) {
-          return etltmrfArray[i]?.refdataValue.value;
-        }    
-      }
+    for (int i = 0; i < etltmrfArray?.size(); i++) {
+      index -= etltmrfArray[i]?.units;
+      if (index <= 0) {
+        return etltmrfArray[i]?.refdataValue.value;
+      }    
     }
+    return ''
   }
 
   public static EnumerationUCTMT handleFormat (EnumerationTemplateMetadataRule rule, LocalDate date, int index, EnumerationUCTMT startingValues){

--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationTextualTMRF.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationTextualTMRF.groovy
@@ -9,8 +9,8 @@ import grails.gorm.MultiTenant
 
 import com.k_int.web.toolkit.refdata.RefdataCategory
 
-
 public class EnumerationTextualTMRF extends EnumerationTemplateMetadataRuleFormat implements MultiTenant<EnumerationTextualTMRF> {
+
   Set<EnumerationTextualLevelTMRF> levels
 
   RefdataCategory refdataCategory

--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationTextualTMRF.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationTextualTMRF.groovy
@@ -7,22 +7,25 @@ import java.time.LocalDate
 
 import grails.gorm.MultiTenant
 
-import com.k_int.web.toolkit.refdata.CategoryId
-import com.k_int.web.toolkit.refdata.Defaults
-import com.k_int.web.toolkit.refdata.RefdataValue
+import com.k_int.web.toolkit.refdata.RefdataCategory
+
 
 public class EnumerationTextualTMRF extends EnumerationTemplateMetadataRuleFormat implements MultiTenant<EnumerationTextualTMRF> {  
   Set<EnumerationTextualLevelTMRF> levels
+
+  RefdataCategory refdataCategory
 
   static hasMany = [
     levels: EnumerationTextualLevelTMRF,
   ]
 
   static mapping = {
+    refdataCategory column: 'ettmrf_refdata_category_fk'
     levels cascade: 'all-delete-orphan', sort: 'index', order: 'asc'
   }
   
   static constraints = {
+    refdataCategory column: false
     levels nullable: false
   }
 
@@ -32,7 +35,7 @@ public class EnumerationTextualTMRF extends EnumerationTemplateMetadataRuleForma
       for (int i = 0; i < etltmrfArray?.size(); i++) {
         index -= etltmrfArray[i]?.units;
         if (index <= 0) {
-          return etltmrfArray[i]?.value;
+          return etltmrfArray[i]?.refdataValue.value;
         }    
       }
     }

--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationTextualTMRF.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationTextualTMRF.groovy
@@ -10,13 +10,17 @@ import grails.gorm.MultiTenant
 import com.k_int.web.toolkit.refdata.RefdataCategory
 
 
-public class EnumerationTextualTMRF extends EnumerationTemplateMetadataRuleFormat implements MultiTenant<EnumerationTextualTMRF> {  
+public class EnumerationTextualTMRF extends EnumerationTemplateMetadataRuleFormat implements MultiTenant<EnumerationTextualTMRF> {
   Set<EnumerationTextualLevelTMRF> levels
 
   RefdataCategory refdataCategory
 
   static hasMany = [
     levels: EnumerationTextualLevelTMRF,
+  ]
+
+  static mappedBy = [
+    levels: 'owner',
   ]
 
   static mapping = {

--- a/service/grails-app/migrations/update-mod-serials-management-1-2.groovy
+++ b/service/grails-app/migrations/update-mod-serials-management-1-2.groovy
@@ -235,4 +235,8 @@ databaseChangeLog = {
       column(name: "ettmrf_refdata_category_fk", type: "VARCHAR(36)")
     }
   }
+
+  changeSet(author: "Jack-Golding (manual)", id: "20250218-1612-003") {
+    dropNotNullConstraint(columnName: "etltmrf_value", tableName: "enumeration_textual_leveltmrf")
+  }
 }

--- a/service/grails-app/migrations/update-mod-serials-management-1-2.groovy
+++ b/service/grails-app/migrations/update-mod-serials-management-1-2.groovy
@@ -223,4 +223,16 @@ databaseChangeLog = {
     dropTable(tableName: "template_metadata_rule_type")
     dropTable(tableName: "template_metadata_rule_format")
   }
+
+  changeSet(author: "Jack-Golding (manual)", id: "20250218-1612-001") {
+    addColumn(tableName: "enumeration_textual_leveltmrf") {
+      column(name: "etlmrf_refdata_value_fk", type: "VARCHAR(36)")
+    }
+  }
+
+  changeSet(author: "Jack-Golding (manual)", id: "20250218-1612-002") {
+    addColumn(tableName: "enumeration_textualtmrf") {
+      column(name: "ettmrf_refdata_category_fk", type: "VARCHAR(36)")
+    }
+  }
 }

--- a/service/grails-app/migrations/update-mod-serials-management-1-2.groovy
+++ b/service/grails-app/migrations/update-mod-serials-management-1-2.groovy
@@ -226,7 +226,7 @@ databaseChangeLog = {
 
   changeSet(author: "Jack-Golding (manual)", id: "20250218-1612-001") {
     addColumn(tableName: "enumeration_textual_leveltmrf") {
-      column(name: "etlmrf_refdata_value_fk", type: "VARCHAR(36)")
+      column(name: "etltmrf_refdata_value_fk", type: "VARCHAR(36)")
     }
   }
 

--- a/service/grails-app/migrations/update-mod-serials-management-1-2.groovy
+++ b/service/grails-app/migrations/update-mod-serials-management-1-2.groovy
@@ -239,4 +239,8 @@ databaseChangeLog = {
   changeSet(author: "Jack-Golding (manual)", id: "20250218-1612-003") {
     dropNotNullConstraint(columnName: "etltmrf_value", tableName: "enumeration_textual_leveltmrf")
   }
+
+  changeSet(author: "Jack-Golding (manual)", id: "20250311-1044-001") {
+    renameColumn(tableName: "enumeration_textual_leveltmrf", oldColumnName: "etltmrf_value", newColumnName: "etltmrf_static_value")
+  }
 }

--- a/service/grails-app/views/enumerationTextualLevelTMRF/_enumerationTextualLevelTMRF.gson
+++ b/service/grails-app/views/enumerationTextualLevelTMRF/_enumerationTextualLevelTMRF.gson
@@ -3,8 +3,7 @@ import org.olf.templateConfig.templateMetadataRuleFormat.EnumerationTextualLevel
 import groovy.transform.Field
 
 def should_expand = [
-  'format',
-  'sequence',
+    'refdataValue'
 ]
 
 @Field EnumerationTextualLevelTMRF enumerationTextualLevelTMRF

--- a/service/grails-app/views/refdataCategory/_refdataCategory.gson
+++ b/service/grails-app/views/refdataCategory/_refdataCategory.gson
@@ -1,5 +1,0 @@
-import groovy.transform.*
-import com.k_int.web.toolkit.refdata.RefdataCategory
-
-@Field RefdataCategory refdataCategory
-json g.render(refdataCategory, [excludes:['values'] ])

--- a/service/grails-app/views/refdataCategory/_refdataCategory.gson
+++ b/service/grails-app/views/refdataCategory/_refdataCategory.gson
@@ -1,0 +1,5 @@
+import groovy.transform.*
+import com.k_int.web.toolkit.refdata.RefdataCategory
+
+@Field RefdataCategory refdataCategory
+json g.render(refdataCategory, [excludes:['values'] ])

--- a/service/grails-app/views/templateMetadataRuleFormat/_enumerationTextualTMRF.gson
+++ b/service/grails-app/views/templateMetadataRuleFormat/_enumerationTextualTMRF.gson
@@ -6,8 +6,13 @@ import groovy.transform.Field
 
 def should_expand = [
   'levels',
-  'refdataCategory'
 ]
 
 @Field EnumerationTextualTMRF ruleFormat
-json g.render(ruleFormat, [excludes: ['owner'], expand: should_expand])
+json g.render(ruleFormat, [excludes: ['owner', 'refdataCategory'], expand: should_expand]){
+    refdataCategory {
+        id ruleFormat.refdataCategory.id
+        desc ruleFormat.refdataCategory.desc
+        internal ruleFormat.refdataCategory.internal
+    }
+}

--- a/service/grails-app/views/templateMetadataRuleFormat/_enumerationTextualTMRF.gson
+++ b/service/grails-app/views/templateMetadataRuleFormat/_enumerationTextualTMRF.gson
@@ -6,6 +6,7 @@ import groovy.transform.Field
 
 def should_expand = [
   'levels',
+  'refdataCategory'
 ]
 
 @Field EnumerationTextualTMRF ruleFormat


### PR DESCRIPTION
We currently only store the textual enumeration labels, and not the reference data IDs. This means that when editing/copying and deprecating a publication pattern or using a template to fill out the publication pattern, if there is a textual enumeration the correct pick list and values are not added to the form correctly

To enable us to use the correct pick list and values, the relevant reference data category and reference data value IDs should be stored rather than the reference data labels as currently.

refs MODSER-99/UISER-191