### PR TITLE
MODSER-105: Attempting to create a ModelRuleset with an owner causes an error

### DIFF
--- a/service/grails-app/controllers/org/olf/ModelRulesetController.groovy
+++ b/service/grails-app/controllers/org/olf/ModelRulesetController.groovy
@@ -24,8 +24,21 @@ class ModelRulesetController extends OkapiTenantAwareController<ModelRulesetCont
     ModelRuleset.withTransaction {
       def data = getObjectToBind()
 
-      SerialRuleset ruleset = new SerialRuleset(data?.serialRuleset)
+      // TODO We should be naming this serialRuleset, it should just be ruleset
+      // Instantiate a new SerialRuleset here, defining each of the fields
+      // This is to ensure that owner is not passed when instantiating the ruleset
+      // This could be done using bindUsingWhen ref at the ruleset level but this is less of pain
+      SerialRuleset ruleset = new SerialRuleset([
+        rulesetNumber: data?.serialRuleset?.rulesetNumber,
+        description: data?.serialRuleset?.description,
+        rulesetStatus: data?.serialRuleset?.rulesetStatus,
+        recurrence: data?.serialRuleset?.recurrence,
+        omission: data?.serialRuleset?.omission,
+        combination: data?.serialRuleset?.combination,
+        templateConfig: data?.serialRuleset?.templateConfig,
+      ])
 
+      // Now instantiate a new ModelRuleset
       ModelRuleset modelRuleset = new ModelRuleset([
         name: data?.name,
         description: data?.description,
@@ -33,6 +46,7 @@ class ModelRulesetController extends OkapiTenantAwareController<ModelRulesetCont
         modelRulesetStatus: data?.modelRulesetStatus
       ])
 
+      // Bind serial ruleset to model ruleset so that owner is set correctly
       modelRuleset.setSerialRuleset(ruleset)
       modelRuleset.save(failOnError: true)
 


### PR DESCRIPTION
Previously an issue occured when attempting to create a model ruleset with an owner property set within the serialRuleset, this has now been fixed by explicitly defining the SerialRuleset levels at the ModelRuleset controller

MODSER-105