### PR TITLE
MOSER-109: Refdata category nullable change

### DIFF
--- a/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationTextualTMRF.groovy
+++ b/service/grails-app/domain/org/olf/templateConfig/templateMetadataRuleFormat/EnumerationTextualTMRF.groovy
@@ -29,7 +29,7 @@ public class EnumerationTextualTMRF extends EnumerationTemplateMetadataRuleForma
   }
   
   static constraints = {
-    refdataCategory nullable: false
+    refdataCategory nullable: true
     levels nullable: false
   }
 


### PR DESCRIPTION
Changed refdata category on EnumerationTextual to nullable false to prevent old ramsons data from causing errors

MODSER-109