### PR TITLE
MODSER-110: Migrated pattern (Ramsons -> Sunflower) with combination generates incorrect labels for predicted pieces

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## 2.1.0 IN PROGRESS
+  * MODSER-110: Migrated pattern (Ramsons -> Sunflower) with combination generates incorrect labels for predicted pieces 
 
 ## 2.0.1 2025-03-28
   * MODSER-111 Patch mod-serials-management for instability during update

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 ## 2.1.0 IN PROGRESS
-  * MODSER-110: Migrated pattern (Ramsons -> Sunflower) with combination generates incorrect labels for predicted pieces 
+  * MODSER-110: Migrated pattern (Ramsons -> Sunflower) with combination generates incorrect labels for predicted pieces
 
 ## 2.0.1 2025-03-28
   * MODSER-111 Patch mod-serials-management for instability during update

--- a/service/grails-app/services/org/olf/PieceLabellingService.groovy
+++ b/service/grails-app/services/org/olf/PieceLabellingService.groovy
@@ -206,15 +206,15 @@ public class PieceLabellingService {
     ArrayList<EnumerationUCTMT> enumerationTemplateMetadataArray = []
     Iterator<EnumerationTemplateMetadataRule> iterator = templateMetadataRules?.iterator()
     
-    // This block is due to be refactor when we seperate out chronology and enumeration in the starting values
-    // Currently we have to track indexs independently depedending on userConfiguredTemplateMetadataType
+    // This block is due to be refactor when we separate out chronology and enumeration in the starting values
+    // Currently we have to track indexs independently depending on userConfiguredTemplateMetadataType
     int enumerationIndex = 0
     ArrayList<UserConfiguredTemplateMetadata> enumerationStartingValues = startingValues.findAll { it.userConfiguredTemplateMetadataType == 'enumeration' }
 
     while(iterator?.hasNext()){
       EnumerationTemplateMetadataRule currentMetadataRule = iterator.next()
         // previousEnumerationArray might be null
-        EnumerationUCTMT ruleStartingValues = previousEnumerationArray ? previousEnumerationArray?.getAt(enumerationIndex) : enumerationStartingValues.getAt(currentMetadataRule?.index)?.metadataType
+        EnumerationUCTMT ruleStartingValues = previousEnumerationArray ? previousEnumerationArray?.getAt(enumerationIndex) : enumerationStartingValues.getAt(enumerationIndex)?.metadataType
         EnumerationUCTMT enumerationUCTMT = EnumerationTemplateMetadataRule.handleType(currentMetadataRule, standardTM.date, standardTM.index, ruleStartingValues)
 
         enumerationTemplateMetadataArray << enumerationUCTMT
@@ -272,7 +272,7 @@ public class PieceLabellingService {
 
     while(enumerationIterator?.hasNext()){
       EnumerationTemplateMetadataRule currentMetadataRule = enumerationIterator.next()
-        EnumerationUCTMT ruleStartingValues = previousEnumerationArray ? previousEnumerationArray?.getAt(enumerationIndex) : enumerationStartingValues.getAt(currentMetadataRule?.index)?.metadataType
+        EnumerationUCTMT ruleStartingValues = previousEnumerationArray ? previousEnumerationArray?.getAt(enumerationIndex) : enumerationStartingValues.getAt(enumerationIndex)?.metadataType
         EnumerationUCTMT enumerationUCTMT = EnumerationTemplateMetadataRule.handleType(currentMetadataRule, standardTM.date, standardTM.index, ruleStartingValues)
 
         UserConfiguredTemplateMetadata currentUCTM = new UserConfiguredTemplateMetadata([


### PR DESCRIPTION

With the migration from ramsons to sunflower, an issue has arisen where the indexs of enumeration rules wont line up with starting values, this resolves it by using the internal counter