### PR TITLE
[MODORDSTOR-448] Updated order-lines interface version

### DIFF
--- a/service/src/main/okapi/ModuleDescriptor-template.json
+++ b/service/src/main/okapi/ModuleDescriptor-template.json
@@ -313,7 +313,7 @@
   "optional": [
     {
       "id": "order-lines",
-      "version": "3.3"
+      "version": "4.0"
     }
   ],
   "permissionSets": [


### PR DESCRIPTION
## Purpose
[MODORDSTOR-448](https://folio-org.atlassian.net/browse/MODORDSTOR-448) - Make user limit as string field & apply migration

## Approach
Updated the order-lines interface version

## Related PRs
See [acq-models](https://github.com/folio-org/acq-models/pull/519) or [mod-orders-storage](https://github.com/folio-org/mod-orders-storage/pull/476) PRs (there are lots).