### PR TITLE
MODSER-126: Removed offending PK constraint

### DIFF
--- a/service/grails-app/migrations/add-missing-primary-keys-for-trillium.groovy
+++ b/service/grails-app/migrations/add-missing-primary-keys-for-trillium.groovy
@@ -209,13 +209,6 @@ databaseChangeLog = {
       addPrimaryKey(tableName: "internal_combination_piece", columnNames: "ip_id", constraintName: "internal_combination_piecePK")
     }
 
-    changeSet(author: "mchaib (manual)", id: "20250702-1515-31") {
-      preConditions(onFail: 'MARK_RAN') {
-        not { primaryKeyExists(tableName: 'internal_combination_piece_internal_recurrence_piece') }
-      }
-      addPrimaryKey(tableName: "internal_combination_piece_internal_recurrence_piece", columnNames: "internal_combination_piece_recurrence_pieces_id", constraintName: "internal_combination_piece_internal_recurrence_piecePK")
-    }
-
     changeSet(author: "mchaib (manual)", id: "20250702-1515-32") {
       preConditions(onFail: 'MARK_RAN') {
         not { primaryKeyExists(tableName: 'internal_omission_piece') }


### PR DESCRIPTION
Due to migration errors being thrown when attempting to create primary key constraints, this changeset has been reverted for the time being

MODSER-126