### PR TITLE
build: MODSER-120: Bump grails and grails-spring-security (#187)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
 
   agent {
     node {
-      label 'jenkins-agent-java17'
+      label 'jenkins-agent-java17-bigmem'
     }
   }
 

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -108,7 +108,7 @@ dependencies {
 	implementation("org.grails.plugins:async")
   implementation("org.grails.plugins:events")
   implementation("org.grails.plugins:hibernate5")
-  implementation("org.grails.plugins:spring-security-core:6.1.1") // NOT IN LINE WITH GRAILS PATCH VERSION
+  implementation("org.grails.plugins:spring-security-core:6.1.2") // NOT IN LINE WITH GRAILS PATCH VERSION
   // 5.8.9 affected by https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORKSECURITY-6457293
   implementation("org.springframework.security:spring-security-core:5.8.16")
   implementation("org.springframework.security:spring-security-web:5.8.16")

--- a/service/gradle.properties
+++ b/service/gradle.properties
@@ -1,6 +1,6 @@
 # Grails
-grailsVersion=6.1.2
-groovyVersion=3.0.11
+grailsVersion=6.2.3
+groovyVersion=3.0.23
 gormVersion=8.0.3
 
 # Gradle


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODSER-120

Back-port #187 from master to release/2.0.x (Sunflower) to bump spring-expression from 5.3.31 to 5.3.39 fixing https://spring.io/security/cve-2024-38808

* build: Bump grails version and grails-spring-security version
* build(ci): Swap to bigmem jenkins agent which is still in use

(cherry picked from commit e394c567939b763eea3827dcdb68b3f94330f4c0)

Note: If the grails version bump is not wanted for Sunflower we might use this entry in build.gradle instead:

    implementation platform("org.springframework:spring-framework-bom:5.3.39")

